### PR TITLE
Add possibility to create controlled stories with good source code shown

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,63 @@ Each package is available in `packages` directory. Typical structure:
 
 There is straight-forward wizard available after `npm run create` command.
 
+### Writing stories for storybook
+
+Stories are automatically loaded into storybook from `stories.js` file directly in package directory.
+The same thing is with stylesheets, Storybook is automatically loading `styles/main.sass` file.
+
+#### Creating story
+
+You can use standard storybook options or use our helpers for that.
+
+##### Simple story
+
+```js
+import React from 'react'
+
+import Something from './src/Something'
+
+import { createStoriesFactory } from '@talixo/commons/story'
+
+const addStory = createStoriesFactory('Something', module)
+
+addStory('initial', 'some description', () => <Something />)
+addStory('disabled', 'some description', () => <Something disabled />)
+```
+
+##### Controlled story
+
+If you need to show component which needs to keep state somewhere,
+Storybook info addon by default will show source only of Controller.
+Because of that, there is additional helper which will show source code correctly:
+
+```js
+import React from 'react'
+
+import FancyButton from './src/FancyButton'
+
+import { createStoriesFactory } from '@talixo/commons/story'
+
+const addStory = createStoriesFactory('FancyButton', module)
+
+function render (setState, state) {
+  return (
+    <div style={{ fontSize: state.size }}>
+      Text
+      <FancyButton onClick={() => setState({ size: state.size + 1 })}>Increase</FancyButton>
+    </div>
+  )
+}
+
+function getInitialState () {
+  return {
+    size: 10
+  }
+}
+
+addStory.controlled('initial', 'some description', render, getInitialState)
+```
+
 ### Development commands & troubleshooting
 
 Description                                                  | Example

--- a/packages/commons/story.js
+++ b/packages/commons/story.js
@@ -35,26 +35,34 @@ const styles = stylesheet => ({
  * @param {string} name
  * @param {object} module
  *
- * @returns {function(name: string, description: string, render: function)|{ controlled: function(name: string, description: string, render: function, getInitialState: function) }}
+ * @returns {function(name: string, description: string, render: function)|function(name: string, description: string, render: function, infoOptions: object)|{ controlled: function(name: string, description: string, render: function, getInitialState: function, infoOptions: object)|function(name: string, description: string, render: function, getInitialState: function, infoOptions: object) }}
  */
 export function createStoriesFactory (name, module) {
   const stories = storiesOf(name, module)
 
-  function addStory (name, description, render) {
+  function addStory (name, description, render, infoOptions = {}) {
     return stories.add(
       name,
       withInfo({
         styles: styles,
         header: true,
         inline: true,
-        text: description
+        text: description,
+        ...infoOptions
       })(render)
     )
   }
 
   // Create helper for controlled stories
-  addStory.controlled = function addControlledStory (name, description, render, getInitialState) {
-    return addStory(name, description, createController(render, getInitialState))
+  addStory.controlled = function addControlledStory (name, description, render, getInitialState, infoOptions = {}) {
+    // Build controller renderer
+    const controller = createController(render, getInitialState)
+
+    // Exclude controller from prop types list
+    return addStory(name, description, controller, {
+      propTablesExclude: [ controller.Controller ],
+      ...infoOptions
+    })
   }
 
   return addStory

--- a/packages/commons/story.js
+++ b/packages/commons/story.js
@@ -1,6 +1,8 @@
 import { storiesOf } from '@storybook/react'
 import { withInfo } from '@storybook/addon-info'
 
+import createController from './story/createController'
+
 /**
  * Build styles for story
  *
@@ -33,13 +35,13 @@ const styles = stylesheet => ({
  * @param {string} name
  * @param {object} module
  *
- * @returns {function(name: string, description: string, render: function)}
+ * @returns {function(name: string, description: string, render: function)|{ controlled: function(name: string, description: string, render: function, getInitialState: function) }}
  */
 export function createStoriesFactory (name, module) {
   const stories = storiesOf(name, module)
 
-  return (name, description, render) =>
-    stories.add(
+  function addStory (name, description, render) {
+    return stories.add(
       name,
       withInfo({
         styles: styles,
@@ -48,6 +50,14 @@ export function createStoriesFactory (name, module) {
         text: description
       })(render)
     )
+  }
+
+  // Create helper for controlled stories
+  addStory.controlled = function addControlledStory (name, description, render, getInitialState) {
+    return addStory(name, description, createController(render, getInitialState))
+  }
+
+  return addStory
 }
 
 /**

--- a/packages/commons/story.js
+++ b/packages/commons/story.js
@@ -58,9 +58,15 @@ export function createStoriesFactory (name, module) {
     // Build controller renderer
     const controller = createController(render, getInitialState)
 
+    // Build list of excluded components from propTypes table
+    const excludedControllers = [
+      controller.Controller,
+      ...(infoOptions.propTablesExclude || [])
+    ]
+
     // Exclude controller from prop types list
     return addStory(name, description, controller, {
-      propTablesExclude: [ controller.Controller ],
+      propTablesExclude: excludedControllers,
       ...infoOptions
     })
   }

--- a/packages/commons/story/createController.js
+++ b/packages/commons/story/createController.js
@@ -39,7 +39,7 @@ function createController (func, getInitialState = () => ({})) {
 
   // Build some required functions
   const register = e => components.push(e)
-  const update = () => components.forEach(c => c.forceUpdate())
+  const update = () => components.filter(c => c.isMounted()).forEach(c => c.forceUpdate())
   const render = () => func(setState, state)
 
   // Build function to set new state

--- a/packages/commons/story/createController.js
+++ b/packages/commons/story/createController.js
@@ -1,0 +1,48 @@
+import React from 'react'
+
+import { action } from '@storybook/addon-actions'
+
+class Controller extends React.Component {
+  constructor (props) {
+    super(props)
+    this.state = props.initialState
+    props.register(this)
+  }
+
+  render () {
+    return this.props.render()
+  }
+}
+
+const emitSetStateAction = action('setState')
+
+function createController (func, getInitialState = () => {}) {
+  const state = getInitialState()
+
+  const components = []
+
+  const register = e => components.push(e)
+  const update = () => components.forEach(c => c.forceUpdate())
+  const render = () => func(setState, state)
+
+  function setState (nextState) {
+    Object.assign(state, nextState)
+    emitSetStateAction(nextState)
+    update()
+  }
+
+  const Control = class extends Controller {}
+
+  Control.defaultProps = {
+    register: register,
+    render: render
+  }
+
+  return () => (
+    <Control initialState={state}>
+      {render()}
+    </Control>
+  )
+}
+
+export default createController

--- a/packages/commons/story/createController.js
+++ b/packages/commons/story/createController.js
@@ -15,6 +15,14 @@ class Controller extends React.Component {
     props.register(this)
   }
 
+  componentDidMount () {
+    this.props.register(this)
+  }
+
+  componentWillUnmount () {
+    this.props.unregister(this)
+  }
+
   render () {
     return this.props.render()
   }
@@ -39,8 +47,15 @@ function createController (func, getInitialState = () => ({})) {
 
   // Build some required functions
   const register = e => components.push(e)
-  const update = () => components.filter(c => c.isMounted()).forEach(c => c.forceUpdate())
+  const update = () => components.forEach(c => c.forceUpdate())
   const render = () => func(setState, state)
+  const unregister = e => {
+    const index = components.indexOf(e)
+
+    if (index !== -1) {
+      components.splice(index, 1)
+    }
+  }
 
   // Build function to set new state
   function setState (nextState) {
@@ -54,6 +69,7 @@ function createController (func, getInitialState = () => ({})) {
 
   // Set these default properties
   Control.defaultProps = {
+    unregister: unregister,
     register: register,
     render: render
   }

--- a/packages/commons/story/createController.js
+++ b/packages/commons/story/createController.js
@@ -59,11 +59,18 @@ function createController (func, getInitialState = () => ({})) {
   }
 
   // Return a function required by addon-info
-  return () => (
-    <Control initialState={state}>
-      {render()}
-    </Control>
-  )
+  function build () {
+    return (
+      <Control initialState={state}>
+        {render()}
+      </Control>
+    )
+  }
+
+  // And extract also Controller to ignore it in propTypes
+  build.Controller = Control
+
+  return build
 }
 
 export default createController


### PR DESCRIPTION
As @maciek15 have shown and proven, there may be a problem with showing source code of components when we need to control them. Right now it ends up with creating wrapping stateful component which manages stuff inside. In source code section in Storybook it's visible as `<App />` without anything from `render()` method.

This Pull Request is implementing another, almost transparent, a method of creating such controlled components, with a simple syntax - you can see an example in README file.