### PR TITLE
[UI-35] Controlled components updated, does not show Control PropTypes

### DIFF
--- a/packages/shared/story.js
+++ b/packages/shared/story.js
@@ -76,8 +76,8 @@ export function createStoriesFactory (name, module, defaultOptions = {}) {
 
     // Exclude controller from prop types list
     return addStory(name, description, controller, {
-      propTablesExclude: excludedControllers,
-      ...infoOptions
+      ...infoOptions,
+      propTablesExclude: excludedControllers
     })
   }
 


### PR DESCRIPTION
#### Task

- **Issue or task referred:** UI-35
- **Feature or Bugfix:** Bugfix

Changed two lines to overwrite `infoOptions.propTablesExcluded` with `excludedControllers`, fixes #44 
