### PR TITLE
[UI-15] Add examples for existing components

### DIFF
--- a/packages/badge/package.json
+++ b/packages/badge/package.json
@@ -29,6 +29,8 @@
     "react-dom": "^16.2.0"
   },
   "dependencies": {
-    "@talixo/shared": "^1.0.0"
+    "@talixo/button": "^1.0.0",
+    "@talixo/shared": "^1.0.0",
+    "@talixo/tab": "^1.0.0"
   }
 }

--- a/packages/badge/package.json
+++ b/packages/badge/package.json
@@ -20,7 +20,9 @@
   "license": "MIT",
   "devDependencies": {
     "jest": "^21.2.1",
-    "rollup": "^0.57.1"
+    "rollup": "^0.57.1",
+    "@talixo/button": "^1.0.0",
+    "@talixo/tab": "^1.0.0"
   },
   "peerDependencies": {
     "classnames": "^2.2.5",
@@ -29,8 +31,6 @@
     "react-dom": "^16.2.0"
   },
   "dependencies": {
-    "@talixo/button": "^1.0.0",
-    "@talixo/shared": "^1.0.0",
-    "@talixo/tab": "^1.0.0"
+    "@talixo/shared": "^1.0.0"
   }
 }

--- a/packages/badge/stories.js
+++ b/packages/badge/stories.js
@@ -24,7 +24,7 @@ addStory('default', readme, () =>
 addStory('inside button', readme, () =>
   <div>
     <Button>
-      Mail <Badge>10 unreaded</Badge>
+      Mail <Badge>10 unread</Badge>
     </Button>
     <Button color='primary'>
       Warnings <Badge>10 problems</Badge>
@@ -38,7 +38,7 @@ addStory('inside tab', readme, () =>
   <div>
     <Tab>
       Mail
-      <Badge>10 unreaded</Badge>
+      <Badge>10 unread</Badge>
     </Tab>
     <Tab>
       info

--- a/packages/badge/stories.js
+++ b/packages/badge/stories.js
@@ -8,7 +8,10 @@ import { createStoriesFactory, getReadmeDescription } from '@talixo/shared/story
 
 const readme = getReadmeDescription(require('./README.md'))
 
-const addStory = createStoriesFactory('Badge', module)
+const addStory = createStoriesFactory('Badge', module, {
+  propTables: [ Badge ],
+  propTablesExclude: [ Button, Tab ]
+})
 
 addStory('default', readme, () =>
   <div>

--- a/packages/badge/stories.js
+++ b/packages/badge/stories.js
@@ -1,6 +1,8 @@
 import React from 'react'
 
 import Badge from './src/Badge'
+import Button from '@talixo/button'
+import Tab from '@talixo/tab'
 
 import { createStoriesFactory, getReadmeDescription } from '@talixo/shared/story'
 
@@ -8,4 +10,40 @@ const readme = getReadmeDescription(require('./README.md'))
 
 const addStory = createStoriesFactory('Badge', module)
 
-addStory('badge', readme, () => <Badge>10</Badge>)
+addStory('default', readme, () =>
+  <div>
+    <Badge>1</Badge>{' '}
+    <Badge>10</Badge>{' '}
+    <Badge>100</Badge>{' '}
+    <Badge>Badge</Badge>
+  </div>
+)
+addStory('inside button', readme, () =>
+  <div>
+    <Button>
+      Mail <Badge>10 unreaded</Badge>
+    </Button>
+    <Button color='primary'>
+      Warnings <Badge>10 problems</Badge>
+    </Button>
+    <Button color='black'>
+      Trash <Badge>10</Badge>
+    </Button>
+  </div>
+)
+addStory('inside tab', readme, () =>
+  <div>
+    <Tab>
+      Mail
+      <Badge>10 unreaded</Badge>
+    </Tab>
+    <Tab>
+      info
+      <Badge>1</Badge>
+    </Tab>
+    <Tab>
+      Settings
+      <Badge>200</Badge>
+    </Tab>
+  </div>
+)

--- a/packages/badge/styles/geometry.sass
+++ b/packages/badge/styles/geometry.sass
@@ -2,6 +2,6 @@
 
 @include module('badge')
   display: inline-block
-  padding: 0 dp(0.5)
+  padding: 0 dp(.8)
   font-size: $font-size-s
   font-weight: $font-weight-semibold

--- a/packages/button/stories.js
+++ b/packages/button/stories.js
@@ -20,27 +20,27 @@ addStory('default size', readme, () => (
     <Button onClick={click}>
       Default
     </Button>
-    <Button disabled>
+    <Button onClick={click} disabled>
       Default Disabled
     </Button>
     <h2>Button primary</h2>
-    <Button color='primary' onClick={click}>
+    <Button onClick={click} color='primary'>
       Primary
     </Button>
-    <Button color='primary' variant='ghost'>
+    <Button onClick={click} color='primary' variant='ghost'>
       Primary Ghost
     </Button>
-    <Button color='primary' disabled>
+    <Button onClick={click} color='primary' disabled>
       Primary Disabled
     </Button>
     <h2>Button black</h2>
-    <Button color='black'>
+    <Button onClick={click} color='black'>
       Black
     </Button>
-    <Button color='black' variant='ghost'>
+    <Button onClick={click} color='black' variant='ghost'>
       Black Ghost
     </Button>
-    <Button color='black' disabled>
+    <Button onClick={click} color='black' disabled>
       Black Disabled
     </Button>
   </div>
@@ -52,27 +52,27 @@ addStory('small', readme, () => (
     <Button onClick={click} size='small'>
       Default
     </Button>
-    <Button size='small' disabled>
+    <Button onClick={click} size='small' disabled>
       Default Disabled
     </Button>
     <h2>Button primary</h2>
-    <Button color='primary' onClick={click} size='small'>
+    <Button onClick={click} color='primary' size='small'>
       Primary
     </Button>
-    <Button color='primary' variant='ghost' size='small'>
+    <Button onClick={click} color='primary' variant='ghost' size='small'>
       Primary Ghost
     </Button>
-    <Button color='primary' size='small' disabled>
+    <Button onClick={click} color='primary' size='small' disabled>
       Primary Disabled
     </Button>
     <h2>Button black</h2>
-    <Button color='black' size='small'>
+    <Button onClick={click} color='black' size='small'>
       Black
     </Button>
-    <Button color='black' variant='ghost' size='small'>
+    <Button onClick={click} color='black' variant='ghost' size='small'>
       Black Ghost
     </Button>
-    <Button color='black' size='small' disabled>
+    <Button onClick={click} color='black' size='small' disabled>
       Black Disabled
     </Button>
   </div>
@@ -80,16 +80,16 @@ addStory('small', readme, () => (
 
 addStory('full width', readme, () => (
   <div>
-    <Button variant='full-width'>
+    <Button onClick={click} variant='full-width'>
       Default Full Width
     </Button>
-    <Button color='primary' variant='full-width'>
+    <Button onClick={click} color='primary' variant='full-width'>
       Primary Full Width
     </Button>
-    <Button color='black' variant='full-width'>
+    <Button onClick={click} color='black' variant='full-width'>
       Black Full Width
     </Button>
-    <Button color='primary' variant='full-width' disabled>
+    <Button onClick={click} color='primary' variant='full-width' disabled>
       Disabled Full Width
     </Button>
   </div>
@@ -98,45 +98,45 @@ addStory('full width', readme, () => (
 addStory('with icon', readme, () => (
   <div>
     <h2>Default size button with icon</h2>
-    <Button>
+    <Button onClick={click}>
       <Icon name='home' /> Home
     </Button>
-    <Button color='primary'>
+    <Button onClick={click} color='primary'>
       <Icon name='settings' /> Settings
     </Button>
-    <Button color='black'>
+    <Button onClick={click} color='black'>
       <Icon name='cancel' /> Cancel
     </Button>
-    <Button disabled>
-      <Icon name='location_disabled' /> Disabled
+    <Button onClick={click} disabled>
+      <Icon name='do_not_disturb' /> Disabled
     </Button>
 
     <h2>Small button with icon</h2>
-    <Button size='small'>
+    <Button onClick={click} size='small'>
       <Icon name='home' /> Home
     </Button>
-    <Button color='primary' size='small'>
+    <Button onClick={click} color='primary' size='small'>
       <Icon name='settings' /> Settings
     </Button>
-    <Button color='black' size='small'>
+    <Button onClick={click} color='black' size='small'>
       <Icon name='cancel' /> Cancel
     </Button>
-    <Button size='small' disabled>
-      <Icon name='location_disabled' /> Disabled
+    <Button onClick={click} size='small' disabled>
+      <Icon name='do_not_disturb' /> Disabled
     </Button>
 
     <h2>Full width size butoon with icon</h2>
-    <Button variant='full-width'>
+    <Button onClick={click} variant='full-width'>
       <Icon name='home' /> Home
     </Button>
-    <Button color='primary' variant='full-width'>
+    <Button onClick={click} color='primary' variant='full-width'>
       <Icon name='settings' /> Settings
     </Button>
-    <Button color='black' variant='full-width'>
+    <Button onClick={click} color='black' variant='full-width'>
       <Icon name='cancel' /> Cancel
     </Button>
-    <Button variant='full-width' disabled>
-      <Icon name='location_disabled' /> Disabled
+    <Button onClick={click} variant='full-width' disabled>
+      <Icon name='do_not_disturb' /> Disabled
     </Button>
   </div>
 ))

--- a/packages/button/stories.js
+++ b/packages/button/stories.js
@@ -8,7 +8,10 @@ import { action } from '@storybook/addon-actions'
 
 const readme = getReadmeDescription(require('./README.md'))
 
-const addStory = createStoriesFactory('Button', module)
+const addStory = createStoriesFactory('Button', module, {
+  propTables: [ Button ],
+  propTablesExclude: [ Icon ]
+})
 const click = action('button-click')
 
 addStory('default size', readme, () => (

--- a/packages/button/stories.js
+++ b/packages/button/stories.js
@@ -1,88 +1,139 @@
 import React from 'react'
 
 import Icon from '@talixo/icon'
-
 import Button from './src/Button'
 
 import { createStoriesFactory, getReadmeDescription } from '@talixo/shared/story'
+import { action } from '@storybook/addon-actions'
 
 const readme = getReadmeDescription(require('./README.md'))
 
 const addStory = createStoriesFactory('Button', module)
+const click = action('button-click')
 
-addStory('primary-default', readme, () => (
-  <Button color='primary'>
-    Default
-  </Button>
+addStory('button-default-size', readme, () => (
+  <div>
+    <h2>Button default</h2>
+    <Button onClick={click}>
+      Default
+    </Button>
+    <Button disabled>
+      Default Disabled
+    </Button>
+    <h2>Button primary</h2>
+    <Button color='primary' onClick={click}>
+      Primary
+    </Button>
+    <Button color='primary' variant='ghost'>
+      Primary Ghost
+    </Button>
+    <Button color='primary' disabled>
+      Primary Disabled
+    </Button>
+    <h2>Button black</h2>
+    <Button color='black'>
+      Black
+    </Button>
+    <Button color='black' variant='ghost'>
+      Black Ghost
+    </Button>
+    <Button color='black' disabled>
+      Black Disabled
+    </Button>
+  </div>
 ))
 
-addStory('primary-small', readme, () => (
-  <Button color='primary' size='small'>
-    Small
-  </Button>
+addStory('button-small', readme, () => (
+  <div>
+    <h2>Button default</h2>
+    <Button onClick={click} size='small'>
+      Default
+    </Button>
+    <Button size='small' disabled>
+      Default Disabled
+    </Button>
+    <h2>Button primary</h2>
+    <Button color='primary' onClick={click} size='small'>
+      Primary
+    </Button>
+    <Button color='primary' variant='ghost' size='small'>
+      Primary Ghost
+    </Button>
+    <Button color='primary' size='small' disabled>
+      Primary Disabled
+    </Button>
+    <h2>Button black</h2>
+    <Button color='black' size='small'>
+      Black
+    </Button>
+    <Button color='black' variant='ghost' size='small'>
+      Black Ghost
+    </Button>
+    <Button color='black' size='small' disabled>
+      Black Disabled
+    </Button>
+  </div>
 ))
 
-addStory('primary-full-width', readme, () => (
-  <Button color='primary' variant='full-width'>
-    Full width
-  </Button>
-))
-
-addStory('primary-ghost', readme, () => (
-  <Button color='primary' variant='ghost'>
-    Ghost
-  </Button>
-))
-
-addStory('primary-disabled', readme, () => (
-  <Button color='primary' disabled>
-    Disabled
-  </Button>
-))
-addStory('primary-disabled-full-width', readme, () => (
-  <Button color='primary' variant='full-width' disabled>
-    Disabled full-width
-  </Button>
-))
-
-addStory('black-default', readme, () => (
-  <Button color='black'>
-    Black
-  </Button>
-))
-
-addStory('black-small', readme, () => (
-  <Button color='black' size='small'>
-    Black
-  </Button>
-))
-
-addStory('black-full-width', readme, () => (
-  <Button color='black' variant='full-width'>
-    Full width
-  </Button>
-))
-
-addStory('black-ghost', readme, () => (
-  <Button color='black' variant='ghost'>
-    Black
-  </Button>
-))
-
-addStory('black-disabled', readme, () => (
-  <Button color='black' disabled>
-    Disabled
-  </Button>
-))
-
-addStory('black-disabled-full-width', readme, () => (
-  <Button color='black' variant='full-width' disabled>
-    Disabled Full Width
-  </Button>
+addStory('button-full-width', readme, () => (
+  <div>
+    <Button variant='full-width'>
+      Default Full Width
+    </Button>
+    <Button color='primary' variant='full-width'>
+      Primary Full Width
+    </Button>
+    <Button color='black' variant='full-width'>
+      Black Full Width
+    </Button>
+    <Button color='primary' variant='full-width' disabled>
+      Disabled Full Width
+    </Button>
+  </div>
 ))
 
 addStory('with icon', readme, () => (
-  <Button color='primary'>
-    <Icon name='settings' /> Settings
-  </Button>
+  <div>
+    <h2>Default size button with icon</h2>
+    <Button>
+      <Icon name='home' /> Home
+    </Button>
+    <Button color='primary'>
+      <Icon name='settings' /> Settings
+    </Button>
+    <Button color='black'>
+      <Icon name='cancel' /> Cancel
+    </Button>
+    <Button disabled>
+      <Icon name='location_disabled' /> Disabled
+    </Button>
+
+    <h2>Small button with icon</h2>
+    <Button size='small'>
+      <Icon name='home' /> Home
+    </Button>
+    <Button color='primary' size='small'>
+      <Icon name='settings' /> Settings
+    </Button>
+    <Button color='black' size='small'>
+      <Icon name='cancel' /> Cancel
+    </Button>
+    <Button size='small' disabled>
+      <Icon name='location_disabled' /> Disabled
+    </Button>
+
+    <h2>Full width size butoon with icon</h2>
+    <Button variant='full-width'>
+      <Icon name='home' /> Home
+    </Button>
+    <Button color='primary' variant='full-width'>
+      <Icon name='settings' /> Settings
+    </Button>
+    <Button color='black' variant='full-width'>
+      <Icon name='cancel' /> Cancel
+    </Button>
+    <Button variant='full-width' disabled>
+      <Icon name='location_disabled' /> Disabled
+    </Button>
+  </div>
 ))

--- a/packages/button/stories.js
+++ b/packages/button/stories.js
@@ -11,7 +11,7 @@ const readme = getReadmeDescription(require('./README.md'))
 const addStory = createStoriesFactory('Button', module)
 const click = action('button-click')
 
-addStory('button-default-size', readme, () => (
+addStory('default size', readme, () => (
   <div>
     <h2>Button default</h2>
     <Button onClick={click}>
@@ -43,7 +43,7 @@ addStory('button-default-size', readme, () => (
   </div>
 ))
 
-addStory('button-small', readme, () => (
+addStory('small', readme, () => (
   <div>
     <h2>Button default</h2>
     <Button onClick={click} size='small'>
@@ -75,7 +75,7 @@ addStory('button-small', readme, () => (
   </div>
 ))
 
-addStory('button-full-width', readme, () => (
+addStory('full width', readme, () => (
   <div>
     <Button variant='full-width'>
       Default Full Width

--- a/packages/button/styles/geometry.sass
+++ b/packages/button/styles/geometry.sass
@@ -1,19 +1,15 @@
 @import './config'
 
 @include module('button')
-
   padding: dp(1) dp(1.5)
-  border: $border-width solid
+  margin: 0 dp(.2)
+  border: $border-width solid transparent
   border-radius: $border-radius-m
-  background-color: $color-orange-talixo
-  border-color: $color-orange-talixo
   font-size: $font-size-m
   line-height: dp(3)
   cursor: pointer
-  box-shadow: $shadow-m rgba(0, 0, 0, 0.25)
-  color: $color-white
   outline: inherit !important
-  display: flex
+  display: inline-flex
   align-items: center
 
   > *
@@ -23,23 +19,8 @@
     padding: dp(0.5) dp(1.5)
     font-size: $font-size-s
 
-  &--ghost
-    background-color: $color-ghost
-    color: $color-ghost-text
-    border-color: $color-ghost-border
-
-    &:hover
-      color: $color-white
-      background-color: $color-ghost-border
-      border-color: $color-ghost-border
-
-  &:disabled
-    background-color: $color-white
-    border-color: $color-white
-    color: $color-disabled-text
-    cursor: not-allowed
-
   &--full-width
     width: 100%
     border-top-left-radius: 0
     border-top-right-radius: 0
+    margin: 0

--- a/packages/button/styles/theming.sass
+++ b/packages/button/styles/theming.sass
@@ -1,9 +1,22 @@
 @import './config'
 
 @include module('button')
+  box-shadow: $shadow-m rgba(0, 0, 0, 0.25)
+  background-color: $color-white
+
+  &:hover
+    background-color: rgba(0, 0, 0, 0.05)
+
+  &:disabled
+    background-color: $color-white
+    border-color: $color-white
+    color: $color-disabled-text
+    cursor: not-allowed
+
   &--primary
     background-color: $color-orange-talixo
     border-color: $color-orange-talixo
+    color: $color-white
 
     &:hover:not(:disabled):not(:active)
       background-color: $color-orange-hover
@@ -26,6 +39,7 @@
   &--black
     background-color: $color-black
     border-color: $color-black
+    color: $color-white
 
     &:hover:not(:disabled):not(:active)
       background-color: $color-black-hover
@@ -48,3 +62,13 @@
       &:active
         background-color: $color-black-active
         border-color: $color-black-active
+
+  &--ghost
+    background-color: $color-ghost
+    color: $color-ghost-text
+    border-color: $color-ghost-border
+
+    &:hover
+      background-color: $color-ghost
+      color: $color-white
+

--- a/packages/checkbox/stories.js
+++ b/packages/checkbox/stories.js
@@ -10,10 +10,35 @@ const readme = getReadmeDescription(require('./README.md'))
 const addStory = createStoriesFactory('Checkbox', module)
 const change = action('change')
 
-addStory('simple', readme, () => (
+addStory('default', readme, () => (
   <div>
-    <div><Checkbox onChange={change}>simple</Checkbox></div>
-    <div><Checkbox size='large' onChange={change}>large label</Checkbox></div>
-    <div><Checkbox size='small' onChange={change}>small label</Checkbox></div>
+    <Checkbox onChange={change}>Default</Checkbox>
+    <Checkbox onChange={change} defaultChecked>Default checked</Checkbox>
+    <Checkbox onChange={change} disabled>Default disabled</Checkbox>
+    <Checkbox onChange={change} defaultChecked disabled>
+      Default checked and disabled
+    </Checkbox>
+  </div>
+))
+
+addStory('small label', readme, () => (
+  <div>
+    <Checkbox onChange={change} size='small'>Default</Checkbox>
+    <Checkbox onChange={change} size='small' defaultChecked>Default checked</Checkbox>
+    <Checkbox onChange={change} size='small' disabled>Default disabled</Checkbox>
+    <Checkbox onChange={change} size='small' defaultChecked disabled>
+      Default checked and disabled
+    </Checkbox>
+  </div>
+))
+
+addStory('large label', readme, () => (
+  <div>
+    <Checkbox onChange={change} size='large'>Default</Checkbox>
+    <Checkbox onChange={change} size='large' defaultChecked>Default checked</Checkbox>
+    <Checkbox onChange={change} size='large' disabled>Default disabled</Checkbox>
+    <Checkbox onChange={change} size='large' defaultChecked disabled>
+      Default checked and disabled
+    </Checkbox>
   </div>
 ))

--- a/packages/checkbox/styles/theming.sass
+++ b/packages/checkbox/styles/theming.sass
@@ -18,3 +18,7 @@
       background-position: 50% 50%
       border-color: transparent
       background-image: url('data:image/svg+xml;utf8,%3Csvg%20viewBox%3D%220%200%2018%2015%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20d%3D%22M6%2010.7L1.8%206.5.4%207.9%206%2013.5l12-12L16.6.1%206%2010.7z%22%20fill%3D%22%23fff%22%20fill-rule%3D%22evenodd%22%2F%3E%3C%2Fsvg%3E')
+
+    &:disabled
+      + span:first-of-type
+        color: $color-disabled-text

--- a/packages/list/src/List.js
+++ b/packages/list/src/List.js
@@ -37,10 +37,14 @@ List.propTypes = {
   className: PropTypes.string,
 
   /** Bullet to put before */
-  bullet: PropTypes.node.isRequired,
+  bullet: PropTypes.node,
 
   /** List of elements */
   children: PropTypes.node
+}
+
+List.defaultProps = {
+  bullet: '-'
 }
 
 export default List

--- a/packages/list/stories.js
+++ b/packages/list/stories.js
@@ -8,10 +8,13 @@ import List from './src/List'
 
 const readme = getReadmeDescription(require('./README.md'))
 
-const addStory = createStoriesFactory('List', module)
+const addStory = createStoriesFactory('List', module, {
+  propTables: [ List ],
+  propTablesExclude: [ Icon ]
+})
 
-addStory('icon bullet', readme, () => (
-  <List bullet={<Icon name='done' style={{ color: 'green' }} />}>
+addStory('default', readme, () => (
+  <List>
     <span>
       Live ride info, price estimation and flight number <br />tracking
     </span>
@@ -24,18 +27,34 @@ addStory('icon bullet', readme, () => (
     </span>
   </List>
 ))
-
-addStory('~ bullet', readme, () => (
-  <List bullet='~'>
-    <span>
-      Live ride info, price estimation and flight number <br />tracking
-    </span>
-    <span>Standardized, insured service worldwide</span>
-    <span>Different car classes (Taxi, VAN, Limousine)</span>
-    <span>Pre-screened, licensed drivers and vehicles</span>
-    <span>Children seats and other facilities</span>
-    <span>
-      24/7 customer support, 9 languages (EN, DE, ES, FR, IT, <br />PL, RU, CHI, AR)
-    </span>
-  </List>
+// {<Icon name='done' style={{ color: 'green' }} />}
+addStory('custom bullet', readme, () => (
+  <div>
+    <h2>List with custom character bullet "~"</h2>
+    <List bullet='~'>
+      <span>
+        Live ride info, price estimation and flight number <br />tracking
+      </span>
+      <span>Standardized, insured service worldwide</span>
+      <span>Different car classes (Taxi, VAN, Limousine)</span>
+      <span>Pre-screened, licensed drivers and vehicles</span>
+      <span>Children seats and other facilities</span>
+      <span>
+        24/7 customer support, 9 languages (EN, DE, ES, FR, IT, <br />PL, RU, CHI, AR)
+      </span>
+    </List>
+    <h2>List with Icon component as bullet <Icon name='done' style={{ color: 'green' }} /></h2>
+    <List bullet={<Icon name='done' style={{ color: 'green' }} />}>
+      <span>
+        Live ride info, price estimation and flight number <br />tracking
+      </span>
+      <span>Standardized, insured service worldwide</span>
+      <span>Different car classes (Taxi, VAN, Limousine)</span>
+      <span>Pre-screened, licensed drivers and vehicles</span>
+      <span>Children seats and other facilities</span>
+      <span>
+        24/7 customer support, 9 languages (EN, DE, ES, FR, IT, <br />PL, RU, CHI, AR)
+      </span>
+    </List>
+  </div>
 ))

--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -20,7 +20,8 @@
   "license": "MIT",
   "devDependencies": {
     "jest": "^21.2.1",
-    "rollup": "^0.57.1"
+    "rollup": "^0.57.1",
+    "@talixo/button": "^1.0.0"
   },
   "peerDependencies": {
     "classnames": "^2.2.5",
@@ -29,7 +30,6 @@
     "react-dom": "^16.2.0"
   },
   "dependencies": {
-    "@talixo/button": "^1.0.0",
     "@talixo/shared": "^1.0.0"
   }
 }

--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -29,6 +29,7 @@
     "react-dom": "^16.2.0"
   },
   "dependencies": {
+    "@talixo/button": "^1.0.0",
     "@talixo/shared": "^1.0.0"
   }
 }

--- a/packages/modal/stories.js
+++ b/packages/modal/stories.js
@@ -1,6 +1,7 @@
 import React from 'react'
 
 import Modal from './src/Modal'
+import Button from '@talixo/button'
 
 import {
   createStoriesFactory,
@@ -15,14 +16,14 @@ const render = (setState, state) => {
   const modalRoot = document.querySelector('body')
   return (
     <div>
-      <button onClick={() => { setState({ isOpen: !state.isOpen }) }}>
+      <Button onClick={() => { setState({ isOpen: !state.isOpen }) }}>
         Open Modal
-      </button>
+      </Button>
       <Modal isOpen={state.isOpen} root={modalRoot}>
         <h1>Modal</h1>
-        <button onClick={() => { setState({ isOpen: false }) }}>
+        <Button onClick={() => { setState({ isOpen: false }) }}>
           Close Modal
-        </button>
+        </Button>
       </Modal>
     </div>
   )
@@ -33,4 +34,4 @@ const getInitialState = () => {
   }
 }
 
-addStory.controlled('initial', readme, render, getInitialState)
+addStory.controlled('default', readme, render, getInitialState)

--- a/packages/modal/stories.js
+++ b/packages/modal/stories.js
@@ -33,9 +33,5 @@ const getInitialState = () => {
     isOpen: false
   }
 }
-const options = {
-  propTypes: [ Modal, Button ],
-  propTablesExclude: [ Button ]
-}
 
-addStory.controlled('default', readme, render, getInitialState, options)
+addStory.controlled('default', readme, render, getInitialState)

--- a/packages/modal/stories.js
+++ b/packages/modal/stories.js
@@ -33,5 +33,9 @@ const getInitialState = () => {
     isOpen: false
   }
 }
+const options = {
+  propTypes: [ Modal, Button ],
+  propTablesExclude: [ Button ]
+}
 
-addStory.controlled('default', readme, render, getInitialState)
+addStory.controlled('default', readme, render, getInitialState, options)

--- a/packages/notification/stories.js
+++ b/packages/notification/stories.js
@@ -12,55 +12,67 @@ const addStory = createStoriesFactory('Notification', module)
 
 const notifications = [
   {
+    variant: null,
+    title: 'Just a message for you.',
+    message: 'You can always look at other examples',
+    id: 0
+  },
+  {
     variant: 'success',
     title: 'Your user registration was successful.',
     message: 'You may now log-in with the username you have chosen',
-    id: 0
+    id: 1
   },
   {
     variant: 'error',
     title: 'There were some errors with your registration.',
     message: 'You must include both a upper and lower case letters in your password',
-    id: 1
+    id: 2
   },
   {
     variant: 'warning',
     title: 'Warning!',
     message: 'You are using a weak password, we reccomend creating a new one',
-    id: 2
+    id: 3
   },
   {
     variant: 'information',
     title: 'Information',
     message: 'Your booking will be reserved for 24 hours',
-    id: 3
+    id: 4
   }
 ]
 
 // Stories
-
-addStory('success notification', readme, () => (
+addStory('default', readme, () => (
+  <Notification style={{ width: '300px' }}>
+    <strong>Your user registration was successful.</strong>
+    <br />
+    <span>You may now log-in with the username you have chosen</span>
+  </Notification>
+))
+addStory('success', readme, () => (
   <Notification style={{ width: '300px' }} variant='information'>
     <strong>Your user registration was successful.</strong>
     <br />
     <span>You may now log-in with the username you have chosen</span>
   </Notification>
 ))
-addStory('error notification', readme, () => (
+addStory('error', readme, () => (
   <Notification style={{ width: '300px' }} variant='error'>
     <strong>There were some errors with your registration.</strong>
     <br />
     <span>You must include both a upper and lower case letters in your password</span>
   </Notification>
 ))
-addStory('warning notification', readme, () => (
+addStory('warning', readme, () => (
   <Notification style={{ width: '300px' }} variant='warning'>
     <strong>Warning!</strong>
     <br />
     <span>You are using a weak password, we reccomend creating a new one</span>
   </Notification>
 ))
-addStory('information notification', readme, () => (
+addStory('information', readme, () => (
   <Notification style={{ width: '300px' }} variant='information'>
     <strong>Information</strong>
     <br />

--- a/packages/notification/stories.js
+++ b/packages/notification/stories.js
@@ -8,7 +8,9 @@ import NotificationList from './src/NotificationList'
 const readme = getReadmeDescription(require('./README.md'))
 
 // Create factories for story
-const addStory = createStoriesFactory('Notification', module)
+const addStory = createStoriesFactory('Notification', module, {
+  propTypes: [ Notification, NotificationList ]
+})
 
 const notifications = [
   {

--- a/packages/notification/styles/theming.sass
+++ b/packages/notification/styles/theming.sass
@@ -1,11 +1,8 @@
 @import './config'
 
-@include module('notifications')
-
 @include module('notification')
-  background-color: $color-orange-talixo
-  border-color: $color-orange-talixo
   color: $color-black
+  background-color: $color-white
 
   &--primary
     background-color: $color-white

--- a/packages/number-input/README.md
+++ b/packages/number-input/README.md
@@ -29,7 +29,7 @@ className     | string    | n/a     | additional class name passed of input
 hasError      | boolean   | `false` | indicates that input has error
 size          | string    | n/a     | size of input (can be 'small')
 style         | object    | n/a     | additional styling of wrapper
-value         | number    | `0`     | input value
+value         | number    | `0`     | initial input value
 
 ## Changelog
 

--- a/packages/number-input/src/NumberInput.js
+++ b/packages/number-input/src/NumberInput.js
@@ -88,7 +88,7 @@ NumberInput.propTypes = {
   /** Additional styling of wrapper */
   style: PropTypes.object,
 
-  /** Input value */
+  /** initial input value */
   value: PropTypes.number
 }
 

--- a/packages/number-input/stories.js
+++ b/packages/number-input/stories.js
@@ -2,33 +2,35 @@ import React from 'react'
 import { createStoriesFactory, getReadmeDescription } from '@talixo/shared/story'
 
 import NumberInput from './src/NumberInput'
+import { action } from '@storybook/addon-actions'
 
 // Load first paragraph from README file
 const readme = getReadmeDescription(require('./README.md'))
 
 // Create factories for story
 const addStory = createStoriesFactory('NumberInput', module)
+const change = action('change')
 
 // Stories
 
 addStory('default', readme, () => (
   <div>
     <h2>Default number input</h2>
-    <NumberInput />
+    <NumberInput onChange={change} />
     <h2>Default number input with initial value</h2>
-    <NumberInput value={15} />
+    <NumberInput onChange={change} value={15} />
     <h2>Number input with errors</h2>
-    <NumberInput hasError />
+    <NumberInput onChange={change} hasError />
   </div>
 ))
 
 addStory('small', readme, () => (
   <div>
     <h2>Small number input</h2>
-    <NumberInput size='small' />
+    <NumberInput onChange={change} size='small' />
     <h2>Default number input with initial value</h2>
-    <NumberInput size='small' value={15} />
+    <NumberInput onChange={change} size='small' value={15} />
     <h2>Small number input with errors</h2>
-    <NumberInput size='small' hasError />
+    <NumberInput onChange={change} size='small' hasError />
   </div>
 ))

--- a/packages/number-input/stories.js
+++ b/packages/number-input/stories.js
@@ -11,14 +11,24 @@ const addStory = createStoriesFactory('NumberInput', module)
 
 // Stories
 
-addStory('initial', readme, () => (
-  <NumberInput />
+addStory('default', readme, () => (
+  <div>
+    <h2>Default number input</h2>
+    <NumberInput />
+    <h2>Default number input with initial value</h2>
+    <NumberInput value={15} />
+    <h2>Number input with errors</h2>
+    <NumberInput hasError />
+  </div>
 ))
 
 addStory('small', readme, () => (
-  <NumberInput size={'small'} />
-))
-
-addStory('with error', readme, () => (
-  <NumberInput hasError />
+  <div>
+    <h2>Small number input</h2>
+    <NumberInput size='small' />
+    <h2>Default number input with initial value</h2>
+    <NumberInput size='small' value={15} />
+    <h2>Small number input with errors</h2>
+    <NumberInput size='small' hasError />
+  </div>
 ))

--- a/packages/number-input/stories.js
+++ b/packages/number-input/stories.js
@@ -28,7 +28,7 @@ addStory('small', readme, () => (
   <div>
     <h2>Small number input</h2>
     <NumberInput onChange={change} size='small' />
-    <h2>Default number input with initial value</h2>
+    <h2>Small number input with initial value</h2>
     <NumberInput onChange={change} size='small' value={15} />
     <h2>Small number input with errors</h2>
     <NumberInput onChange={change} size='small' hasError />

--- a/packages/number-input/styles/theming.sass
+++ b/packages/number-input/styles/theming.sass
@@ -22,7 +22,7 @@
   &--error
     border-color: $color-talixo-error-red
 
-    > input, &::placeholder > input
+    > input
       color: $color-talixo-error-red
 
   input[type='number']::-webkit-inner-spin-button

--- a/packages/pill/stories.js
+++ b/packages/pill/stories.js
@@ -8,42 +8,24 @@ const readme = getReadmeDescription(require('./README.md'))
 
 const addStory = createStoriesFactory('Pill', module)
 
-addStory('blue', readme, () => (
-  <div style={{ padding: '3em', display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
-    <Pill color='blue'>Hello Pill</Pill>
-  </div>
-))
-addStory('gray', readme, () => (
-  <div style={{ padding: '3em', display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
-    <Pill color='gray'>Hello Pill</Pill>
-  </div>
-))
-addStory('green', readme, () => (
-  <div style={{ padding: '3em', display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
-    <Pill color='green'>Hello Pill</Pill>
-  </div>
-))
-addStory('red', readme, () => (
-  <div style={{ padding: '3em', display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
-    <Pill color='red'>Hello Pill</Pill>
-  </div>
-))
-addStory('yellow', readme, () => (
-  <div style={{ padding: '3em', display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
-    <Pill color='yellow'>Hello Pill</Pill>
-  </div>
-))
-addStory('ghost/red', readme, () => (
-  <div style={{ padding: '3em', display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
-    <Pill variant='ghost' color='red'>
-      Hello Pill
-    </Pill>
-  </div>
-))
-addStory('red with style prop set to padding: 20px', readme, () => (
-  <div style={{ padding: '3em', display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
-    <Pill color='red' style={{ padding: '20px' }}>
-      Hello Pill
-    </Pill>
+addStory('all pills', readme, () => (
+  <div>
+    <h2>Standard Pills</h2>
+    <div style={{ display: 'flex', flexDirection: 'row', alignItems: 'center' }}>
+      <Pill color='blue'>Blue Pill</Pill>
+      <Pill color='gray'>Gray Pill</Pill>
+      <Pill color='green'>Green Pill</Pill>
+      <Pill color='red'>Red Pill</Pill>
+      <Pill color='yellow'>Yellow Pill</Pill>
+    </div>
+
+    <h2>Ghost Pills</h2>
+    <div style={{ display: 'flex', flexDirection: 'row', alignItems: 'center' }}>
+      <Pill color='blue' variant='ghost'>Blue Ghost Pill</Pill>
+      <Pill color='gray' variant='ghost'>Gray Ghost Pill</Pill>
+      <Pill color='green' variant='ghost'>Green Ghost Pill</Pill>
+      <Pill variant='ghost' color='red'>Red Ghost Pill</Pill>
+      <Pill color='yellow' variant='ghost'>Yellow Ghost Pill</Pill>
+    </div>
   </div>
 ))

--- a/packages/pill/stories.js
+++ b/packages/pill/stories.js
@@ -12,6 +12,7 @@ addStory('all pills', readme, () => (
   <div>
     <h2>Standard Pills</h2>
     <div style={{ display: 'flex', flexDirection: 'row', alignItems: 'center' }}>
+      <Pill>Default Pill</Pill>
       <Pill color='blue'>Blue Pill</Pill>
       <Pill color='gray'>Gray Pill</Pill>
       <Pill color='green'>Green Pill</Pill>
@@ -21,6 +22,7 @@ addStory('all pills', readme, () => (
 
     <h2>Ghost Pills</h2>
     <div style={{ display: 'flex', flexDirection: 'row', alignItems: 'center' }}>
+      <Pill variant='ghost'>Default Ghost Pill</Pill>
       <Pill color='blue' variant='ghost'>Blue Ghost Pill</Pill>
       <Pill color='gray' variant='ghost'>Gray Ghost Pill</Pill>
       <Pill color='green' variant='ghost'>Green Ghost Pill</Pill>

--- a/packages/pill/styles/geometry.sass
+++ b/packages/pill/styles/geometry.sass
@@ -4,7 +4,5 @@
   display: inline-block
   padding: dp(0.5) dp(2)
   border: $border-width solid $navy
-  border-radius: $border-radius-pill
-  background-color: $navy
   font-size: $font-size-s
   font-weight: $font-weight-semibold

--- a/packages/pill/styles/theming.sass
+++ b/packages/pill/styles/theming.sass
@@ -1,9 +1,6 @@
 @import './config'
 
 @include module('pill')
-  &--ghost
-    border-color: $color-ghost-border
-
   &--blue
     background-color: $color-pill-blue
     border-color: $color-pill-blue

--- a/packages/pill/styles/theming.sass
+++ b/packages/pill/styles/theming.sass
@@ -1,25 +1,35 @@
 @import './config'
 
 @include module('pill')
+  border-radius: $border-radius-pill
+  background-color: $navy
+  color: $color-white
+
   &--blue
     background-color: $color-pill-blue
     border-color: $color-pill-blue
+    color: $color-black
 
   &--gray
     background-color: $color-pill-gray
     border-color: $color-pill-gray
+    color: $color-black
 
   &--green
     background-color: $color-pill-green
     border-color: $color-pill-green
+    color: $color-black
 
   &--red
     background-color: $color-orange-talixo
     border-color: $color-orange-talixo
+    color: $color-black
 
   &--yellow
     background-color: $color-pill-yellow
     border-color: $color-pill-yellow
+    color: $color-black
 
   &--ghost
     background-color: $color-ghost
+    color: $color-black

--- a/packages/radio-input/README.md
+++ b/packages/radio-input/README.md
@@ -27,6 +27,7 @@ Property name | Type      | Default | Description
 --------------|-----------|:-------:|--------------------------------
 children      | node      | n/a     | radio button description 
 className     | string    | n/a     | additional class name passed to wrapper
+size          | string    | n/a     | checkbox label size ('small' or 'large')
 style         | object    | n/a     | styles passed to wrapper
 
 ## Changelog

--- a/packages/radio-input/src/RadioInput.js
+++ b/packages/radio-input/src/RadioInput.js
@@ -12,6 +12,7 @@ const moduleName = prefix('radio-input')
  * @param {object} props
  * @param {node} [props.children]
  * @param {string} [props.className]
+ * @param {string} [props.size]
  * @param {object} [props.style]
  * @returns {React.Element}
  */

--- a/packages/radio-input/src/RadioInput.js
+++ b/packages/radio-input/src/RadioInput.js
@@ -16,9 +16,12 @@ const moduleName = prefix('radio-input')
  * @returns {React.Element}
  */
 function RadioInput (props) {
-  const { children, className, style, ...passedProps } = props
+  const { children, className, size, style, ...passedProps } = props
 
-  const wrapperClass = cls(moduleName, className)
+  const wrapperClass = cls(moduleName, className, {
+    [`${moduleName}--${size}`]: size != null
+  }
+  )
 
   return (
     <label className={wrapperClass} style={style}>
@@ -34,6 +37,9 @@ RadioInput.propTypes = {
 
   /** Additional wrapper class name */
   className: PropTypes.string,
+
+  /** Radio input label size ('small', 'large') */
+  size: PropTypes.oneOf([ 'small', 'large' ]),
 
   /** Styles passed to radio button wrapper */
   style: PropTypes.object

--- a/packages/radio-input/stories.js
+++ b/packages/radio-input/stories.js
@@ -2,68 +2,70 @@ import React from 'react'
 import { createStoriesFactory, getReadmeDescription } from '@talixo/shared/story'
 
 import RadioInput from './src/RadioInput'
+import {action} from '@storybook/addon-actions'
 
 // Load first paragraph from README file
 const readme = getReadmeDescription(require('./README.md'))
 
 // Create factories for story
 const addStory = createStoriesFactory('Radio Input', module)
+const change = action('change')
 
 // Stories
 
 addStory('default', readme, () => (
   <div>
-    <h3>Radio group default</h3>
-    <RadioInput name='default'>Option</RadioInput>
-    <RadioInput name='default'>Option two</RadioInput>
+    <h2>Default radio</h2>
+    <RadioInput onChange={change} name='default'>Option</RadioInput>
+    <RadioInput onChange={change} name='default'>Option two</RadioInput>
     <br /><br />
 
-    <h3>Radio group with default value</h3>
-    <RadioInput name='default_checked'>Option</RadioInput>
-    <RadioInput name='default_checked' defaultChecked>Option default checked</RadioInput>
+    <h2>Radio group with default value</h2>
+    <RadioInput onChange={change} name='default_checked'>Option</RadioInput>
+    <RadioInput onChange={change} name='default_checked' defaultChecked>Option default checked</RadioInput>
     <br /><br />
 
-    <h3>Default radio with disabled opition</h3>
-    <RadioInput name='default_disabled'>Option</RadioInput>
-    <RadioInput name='default_disabled' defaultChecked>Option default checked</RadioInput>
-    <RadioInput name='default_disabled' disabled>Option disabled</RadioInput>
+    <h2>Default radio with disabled opition</h2>
+    <RadioInput onChange={change} name='default_disabled'>Option</RadioInput>
+    <RadioInput onChange={change} name='default_disabled' defaultChecked>Option default checked</RadioInput>
+    <RadioInput onChange={change} name='default_disabled' disabled>Option disabled</RadioInput>
   </div>
 ))
 
 addStory('small', readme, () => (
   <div>
-    <h3>Radio group default</h3>
-    <RadioInput size='small' name='default'>Option</RadioInput>
-    <RadioInput size='small' name='default'>Option two</RadioInput>
+    <h2>Default radio</h2>
+    <RadioInput onChange={change} size='small' name='default'>Option</RadioInput>
+    <RadioInput onChange={change} size='small' name='default'>Option two</RadioInput>
     <br /><br />
 
-    <h3>Radio group with default value</h3>
-    <RadioInput size='small' name='default_checked'>Option</RadioInput>
-    <RadioInput size='small' name='default_checked' defaultChecked>Option default checked</RadioInput>
+    <h2>Radio group with default value</h2>
+    <RadioInput onChange={change} size='small' name='default_checked'>Option</RadioInput>
+    <RadioInput onChange={change} size='small' name='default_checked' defaultChecked>Option default checked</RadioInput>
     <br /><br />
 
-    <h3>Default radio with disabled opition</h3>
-    <RadioInput size='small' name='default_disabled'>Option</RadioInput>
-    <RadioInput size='small' name='default_disabled' defaultChecked>Option default checked</RadioInput>
-    <RadioInput size='small' name='default_disabled' disabled>Option disabled</RadioInput>
+    <h2>Default radio with disabled opition</h2>
+    <RadioInput onChange={change} size='small' name='default_disabled'>Option</RadioInput>
+    <RadioInput onChange={change} size='small' name='default_disabled' defaultChecked>Option default checked</RadioInput>
+    <RadioInput onChange={change} size='small' name='default_disabled' disabled>Option disabled</RadioInput>
   </div>
 ))
 
 addStory('large', readme, () => (
   <div>
-    <h3>Radio group default</h3>
-    <RadioInput size='large' name='default'>Option</RadioInput>
-    <RadioInput size='large' name='default'>Option two</RadioInput>
+    <h2>Default radio</h2>
+    <RadioInput onChange={change} size='large' name='default'>Option</RadioInput>
+    <RadioInput onChange={change} size='large' name='default'>Option two</RadioInput>
     <br /><br />
 
-    <h3>Radio group with default value</h3>
-    <RadioInput size='large' name='default_checked'>Option</RadioInput>
-    <RadioInput size='large' name='default_checked' defaultChecked>Option default checked</RadioInput>
+    <h2>Radio group with default value</h2>
+    <RadioInput onChange={change} size='large' name='default_checked'>Option</RadioInput>
+    <RadioInput onChange={change} size='large' name='default_checked' defaultChecked>Option default checked</RadioInput>
     <br /><br />
 
-    <h3>Default radio with disabled opition</h3>
-    <RadioInput size='large' name='default_disabled'>Option</RadioInput>
-    <RadioInput size='large' name='default_disabled' defaultChecked>Option default checked</RadioInput>
-    <RadioInput size='large' name='default_disabled' disabled>Option disabled</RadioInput>
+    <h2>Default radio with disabled opition</h2>
+    <RadioInput onChange={change} size='large' name='default_disabled'>Option</RadioInput>
+    <RadioInput onChange={change} size='large' name='default_disabled' defaultChecked>Option default checked</RadioInput>
+    <RadioInput onChange={change} size='large' name='default_disabled' disabled>Option disabled</RadioInput>
   </div>
 ))

--- a/packages/radio-input/stories.js
+++ b/packages/radio-input/stories.js
@@ -11,10 +11,59 @@ const addStory = createStoriesFactory('Radio Input', module)
 
 // Stories
 
-addStory('initial', readme, () => (
+addStory('default', readme, () => (
   <div>
-    <h3>Test radio</h3>
-    <RadioInput name='test' defaultChecked>Option 1</RadioInput>
-    <RadioInput name='test'>Option 2</RadioInput>
+    <h3>Radio group default</h3>
+    <RadioInput name='default'>Option</RadioInput>
+    <RadioInput name='default'>Option two</RadioInput>
+    <br /><br />
+
+    <h3>Radio group with default value</h3>
+    <RadioInput name='default_checked'>Option</RadioInput>
+    <RadioInput name='default_checked' defaultChecked>Option default checked</RadioInput>
+    <br /><br />
+
+    <h3>Default radio with disabled opition</h3>
+    <RadioInput name='default_disabled'>Option</RadioInput>
+    <RadioInput name='default_disabled' defaultChecked>Option default checked</RadioInput>
+    <RadioInput name='default_disabled' disabled>Option disabled</RadioInput>
+  </div>
+))
+
+addStory('small', readme, () => (
+  <div>
+    <h3>Radio group default</h3>
+    <RadioInput size='small' name='default'>Option</RadioInput>
+    <RadioInput size='small' name='default'>Option two</RadioInput>
+    <br /><br />
+
+    <h3>Radio group with default value</h3>
+    <RadioInput size='small' name='default_checked'>Option</RadioInput>
+    <RadioInput size='small' name='default_checked' defaultChecked>Option default checked</RadioInput>
+    <br /><br />
+
+    <h3>Default radio with disabled opition</h3>
+    <RadioInput size='small' name='default_disabled'>Option</RadioInput>
+    <RadioInput size='small' name='default_disabled' defaultChecked>Option default checked</RadioInput>
+    <RadioInput size='small' name='default_disabled' disabled>Option disabled</RadioInput>
+  </div>
+))
+
+addStory('large', readme, () => (
+  <div>
+    <h3>Radio group default</h3>
+    <RadioInput size='large' name='default'>Option</RadioInput>
+    <RadioInput size='large' name='default'>Option two</RadioInput>
+    <br /><br />
+
+    <h3>Radio group with default value</h3>
+    <RadioInput size='large' name='default_checked'>Option</RadioInput>
+    <RadioInput size='large' name='default_checked' defaultChecked>Option default checked</RadioInput>
+    <br /><br />
+
+    <h3>Default radio with disabled opition</h3>
+    <RadioInput size='large' name='default_disabled'>Option</RadioInput>
+    <RadioInput size='large' name='default_disabled' defaultChecked>Option default checked</RadioInput>
+    <RadioInput size='large' name='default_disabled' disabled>Option disabled</RadioInput>
   </div>
 ))

--- a/packages/radio-input/styles/geometry.sass
+++ b/packages/radio-input/styles/geometry.sass
@@ -24,3 +24,11 @@
       flex: 1 1 auto
       margin: 0 dp(4.4)
       font-size: $font-size-m
+
+
+  &#{prefix('radio-input--small')} > span:first-of-type
+    font-size: $font-size-s
+
+
+  &#{prefix('radio-input--large')} > span:first-of-type
+    font-size: $font-size-l

--- a/packages/radio-input/styles/theming.sass
+++ b/packages/radio-input/styles/theming.sass
@@ -5,6 +5,9 @@
   input
     display: none
 
+    &:disabled + span
+      color: $color-disabled-text
+
   span:before
     border: $border-width solid $color-ghost-border
     transform: rotate(360deg)

--- a/packages/switcher/stories.js
+++ b/packages/switcher/stories.js
@@ -13,9 +13,17 @@ const readme = getReadmeDescription(require('./README.md'))
 const addStory = createStoriesFactory('Switcher', module)
 const change = action('change')
 
-addStory('not controlled', readme, () => <Switcher onChange={change} />)
-addStory('selected', readme, () => <Switcher onChange={change} checked />)
-addStory('disabled', readme, () => <Switcher onChange={change} disabled />)
-addStory('disabled & selected', readme, () => (
-  <Switcher onChange={change} disabled checked />
-))
+addStory('all options', readme, () =>
+  <div>
+    <h2>Default</h2>
+    <Switcher onChange={change} />
+    <h2>Default checked</h2>
+    <Switcher onChange={change} defaultChecked />
+    <h2>Always checked</h2>
+    <Switcher onChange={change} checked />
+    <h2>Disabled</h2>
+    <Switcher onChange={change} disabled />
+    <h2>Disabled and checked</h2>
+    <Switcher onChange={change} disabled checked />
+  </div>
+)

--- a/packages/tab/package.json
+++ b/packages/tab/package.json
@@ -20,7 +20,8 @@
   "license": "MIT",
   "devDependencies": {
     "jest": "^21.2.1",
-    "rollup": "^0.57.1"
+    "rollup": "^0.57.1",
+    "@talixo/badge": "^1.0.0"
   },
   "peerDependencies": {
     "classnames": "^2.2.5",
@@ -29,7 +30,6 @@
     "react-dom": "^16.2.0"
   },
   "dependencies": {
-    "@talixo/shared": "^1.0.0",
-    "@talixo/badge": "^1.0.0"
+    "@talixo/shared": "^1.0.0"
   }
 }

--- a/packages/tab/stories.js
+++ b/packages/tab/stories.js
@@ -8,7 +8,10 @@ import Tab from './src/Tab'
 const readme = getReadmeDescription(require('./README.md'))
 
 // Create factories for story
-const addStory = createStoriesFactory('Tab', module)
+const addStory = createStoriesFactory('Tab', module, {
+  propTables: [ Tab ],
+  propTablesExclude: [ Badge ]
+})
 
 // Stories
 

--- a/packages/table/stories.js
+++ b/packages/table/stories.js
@@ -16,7 +16,10 @@ import Action from './src/Action'
 const readme = getReadmeDescription(require('./README.md'))
 
 // Create factories for story
-const addStory = createStoriesFactory('Table', module)
+const addStory = createStoriesFactory('Table', module, {
+  inline: false,
+  propTypes: [ Table, Head, Body, Footer, HeadCell, Row, Cell, ActionsCell, Action ]
+})
 
 // Build default actions
 const assign = action('Assign')

--- a/packages/text-input/stories.js
+++ b/packages/text-input/stories.js
@@ -18,10 +18,12 @@ const additionalStyling = {
 
 addStory('default', readme, () => (
   <div>
+    <h2>Default text input</h2>
     <TextInput
       placeholder='Default input'
       style={additionalStyling}
     />
+    <h2>Default text input with error </h2>
     <TextInput
       placeholder='Default input with errors'
       style={additionalStyling}
@@ -31,11 +33,13 @@ addStory('default', readme, () => (
 ))
 addStory('small', readme, () => (
   <div>
+    <h2>Small text input</h2>
     <TextInput
       placeholder='Small text input'
       size='small'
       style={additionalStyling}
     />
+    <h2>Small text input with error</h2>
     <TextInput
       placeholder='Small text input with errors'
       size='small'

--- a/packages/text-input/stories.js
+++ b/packages/text-input/stories.js
@@ -2,12 +2,14 @@ import React from 'react'
 import { createStoriesFactory, getReadmeDescription } from '@talixo/shared/story'
 
 import TextInput from './src/TextInput'
+import {action} from '@storybook/addon-actions'
 
 // Load first paragraph from README file
 const readme = getReadmeDescription(require('./README.md'))
 
 // Create factories for story
 const addStory = createStoriesFactory('Text Input', module)
+const change = action('change')
 
 // Stories
 
@@ -22,11 +24,13 @@ addStory('default', readme, () => (
     <TextInput
       placeholder='Default input'
       style={additionalStyling}
+      onChange={change}
     />
     <h2>Default text input with error </h2>
     <TextInput
       placeholder='Default input with errors'
       style={additionalStyling}
+      onChange={change}
       hasError
     />
   </div>
@@ -38,12 +42,14 @@ addStory('small', readme, () => (
       placeholder='Small text input'
       size='small'
       style={additionalStyling}
+      onChange={change}
     />
     <h2>Small text input with error</h2>
     <TextInput
       placeholder='Small text input with errors'
       size='small'
       style={additionalStyling}
+      onChange={change}
       hasError
     />
   </div>

--- a/packages/text-input/styles/geometry.sass
+++ b/packages/text-input/styles/geometry.sass
@@ -10,7 +10,7 @@
 
   &:focus ~ #{prefix('text-input', 'label')},
   ~ #{prefix('text-input', 'label')}#{prefix('text-input', 'label--not-empty')}
-    top: dp(.6)
+    top: dp(.3)
     font-size: dp(1.4)
 
 #{prefix('text-input', 'wrapper')}
@@ -24,8 +24,8 @@
 #{prefix('text-input', 'label')}
   position: absolute
   left: dp(2)
-  top: calc(50% - (.5 * #{$font-size-m}))
+  top: calc(50% - (.7 * #{$font-size-m}))
   transition: .3s ease all
 
   &--small
-    top: calc(50% - (.5 * #{$font-size-s}))
+    top: calc(50% - (.8 * #{$font-size-s}))


### PR DESCRIPTION
#### Task

- **Issue or task referred:** UI-15
- **Feature or Bugfix:** Feature

I've added more Storybook examples to components listed below. I did not apply any changes to components that will be refactored: Breadcrumbs, Popover, Tooltip. Additionally I've made some changes to some components styling.

#### Components

- Button (minimal margin to both sides)
- Badge (padding and default colors added)
- Checkbox
- List (default bullet added -> '-')
- Modal
- Notification (default style added)
- NumberInput
- Pill(default styling added)
- Radio (sizes added: 'small', large')
- Switcher
- TextInput
