### PR TITLE
Add unit tests for Sidebar

### DIFF
--- a/packages/button/tests/Button.test.js
+++ b/packages/button/tests/Button.test.js
@@ -50,6 +50,6 @@ describe('<Button />', () => {
       </Button>
     )
 
-    expect(wrapper.props().type).toEqual('button')
+    expect(wrapper.props().type).toBe('button')
   })
 })

--- a/packages/collapse/tests/Collapse.test.js
+++ b/packages/collapse/tests/Collapse.test.js
@@ -71,7 +71,7 @@ describe('<Collapse />', () => {
       </Collapse>
     )
 
-    expect(wrapper.instance().getHeight()).toEqual(wrapper.find('.talixo-collapse__content').getDOMNode().offsetHeight)
+    expect(wrapper.instance().getHeight()).toBe(wrapper.find('.talixo-collapse__content').getDOMNode().offsetHeight)
 
     wrapper.unmount()
   })
@@ -87,7 +87,7 @@ describe('<Collapse />', () => {
 
     wrapper.unmount()
 
-    expect(instance.getHeight()).toEqual(null)
+    expect(instance.getHeight()).toBe(null)
   })
 
   it('should return no height when it\'s not mounted', () => {
@@ -101,7 +101,7 @@ describe('<Collapse />', () => {
 
     wrapper.unmount()
 
-    expect(instance.getHeight()).toEqual(null)
+    expect(instance.getHeight()).toBe(null)
   })
 
   it('should not set max-height after first initialization', () => {
@@ -113,8 +113,8 @@ describe('<Collapse />', () => {
 
     const instance = wrapper.instance()
 
-    expect(instance.height).toEqual(null)
-    expect(wrapper.getDOMNode().style.maxHeight).toEqual('')
+    expect(instance.height).toBe(null)
+    expect(wrapper.getDOMNode().style.maxHeight).toBe('')
 
     wrapper.unmount()
   })
@@ -134,8 +134,8 @@ describe('<Collapse />', () => {
 
     const height = wrapper.find('.talixo-collapse__content').getDOMNode().offsetHeight
 
-    expect(instance.height).toEqual(height)
-    expect(wrapper.getDOMNode().style.maxHeight).toEqual('' + height)
+    expect(instance.height).toBe(height)
+    expect(wrapper.getDOMNode().style.maxHeight).toBe('' + height)
 
     wrapper.unmount()
   })
@@ -153,8 +153,8 @@ describe('<Collapse />', () => {
 
     wrapper.setProps({ collapsed: false })
 
-    expect(instance.height).toEqual(null)
-    expect(wrapper.getDOMNode().style.maxHeight).toEqual('')
+    expect(instance.height).toBe(null)
+    expect(wrapper.getDOMNode().style.maxHeight).toBe('')
 
     wrapper.unmount()
   })
@@ -174,15 +174,15 @@ describe('<Collapse />', () => {
 
     const height = wrapper.find('.talixo-collapse__content').getDOMNode().offsetHeight
 
-    expect(instance.height).toEqual(height)
-    expect(wrapper.getDOMNode().style.maxHeight).toEqual('' + height)
+    expect(instance.height).toBe(height)
+    expect(wrapper.getDOMNode().style.maxHeight).toBe('' + height)
 
     // Check after finishing transition
 
     instance.finishTransition({ target: instance.node })
 
-    expect(instance.height).toEqual(null)
-    expect(wrapper.getDOMNode().style.maxHeight).toEqual('')
+    expect(instance.height).toBe(null)
+    expect(wrapper.getDOMNode().style.maxHeight).toBe('')
 
     wrapper.unmount()
   })
@@ -202,19 +202,19 @@ describe('<Collapse />', () => {
 
     const height = wrapper.find('.talixo-collapse__content').getDOMNode().offsetHeight
 
-    expect(instance.height).toEqual(height)
-    expect(wrapper.getDOMNode().style.maxHeight).toEqual('' + height)
-    expect(wrapper.getDOMNode().style.background).toEqual('red')
+    expect(instance.height).toBe(height)
+    expect(wrapper.getDOMNode().style.maxHeight).toBe('' + height)
+    expect(wrapper.getDOMNode().style.background).toBe('red')
 
     // Check after finishing transition
 
     instance.finishTransition({ target: instance.node })
     instance.forceUpdate()
 
-    expect(instance.height).toEqual(null)
+    expect(instance.height).toBe(null)
 
-    expect(wrapper.getDOMNode().style.maxHeight).toEqual('10px')
-    expect(wrapper.getDOMNode().style.background).toEqual('red')
+    expect(wrapper.getDOMNode().style.maxHeight).toBe('10px')
+    expect(wrapper.getDOMNode().style.background).toBe('red')
 
     wrapper.unmount()
   })
@@ -234,17 +234,17 @@ describe('<Collapse />', () => {
 
     const height = wrapper.find('.talixo-collapse__content').getDOMNode().offsetHeight
 
-    expect(instance.height).toEqual(height)
-    expect(wrapper.getDOMNode().style.maxHeight).toEqual('' + height)
-    expect(wrapper.getDOMNode().style.background).toEqual('red')
+    expect(instance.height).toBe(height)
+    expect(wrapper.getDOMNode().style.maxHeight).toBe('' + height)
+    expect(wrapper.getDOMNode().style.background).toBe('red')
 
     // Check after finishing transition
 
     instance.finishTransition({ target: instance.node })
 
-    expect(instance.height).toEqual(null)
-    expect(wrapper.getDOMNode().style.maxHeight).toEqual('')
-    expect(wrapper.getDOMNode().style.background).toEqual('red')
+    expect(instance.height).toBe(null)
+    expect(wrapper.getDOMNode().style.maxHeight).toBe('')
+    expect(wrapper.getDOMNode().style.background).toBe('red')
 
     wrapper.unmount()
   })
@@ -268,8 +268,8 @@ describe('<Collapse />', () => {
 
     instance.finishTransition({ target: wrapper.find('.talixo-collapse__content').getDOMNode() })
 
-    expect(instance.height).toEqual(height)
-    expect(wrapper.getDOMNode().style.maxHeight).toEqual('' + height)
+    expect(instance.height).toBe(height)
+    expect(wrapper.getDOMNode().style.maxHeight).toBe('' + height)
 
     wrapper.unmount()
   })
@@ -281,8 +281,8 @@ describe('<Collapse />', () => {
       </Collapse>
     )
 
-    expect(wrapper.getDOMNode().style.transitionDuration).toEqual('1000ms')
-    expect(wrapper.getDOMNode().style.animationDuration).toEqual('1000ms')
+    expect(wrapper.getDOMNode().style.transitionDuration).toBe('1000ms')
+    expect(wrapper.getDOMNode().style.animationDuration).toBe('1000ms')
 
     wrapper.unmount()
   })

--- a/packages/combo-box/tests/DropdownButton.test.js
+++ b/packages/combo-box/tests/DropdownButton.test.js
@@ -14,36 +14,36 @@ describe('<DropdownButton />', () => {
 
   it('renders no placeholder by default', () => {
     const wrapper = mount(<DropdownButton />)
-    expect(wrapper.find(`.${name}__item`).exists()).toEqual(true)
-    expect(wrapper.find(`.${name}__item`).contains('Number')).toEqual(false)
+    expect(wrapper.find(`.${name}__item`).exists()).toBe(true)
+    expect(wrapper.find(`.${name}__item`).contains('Number')).toBe(false)
     wrapper.unmount()
   })
 
   it('renders placeholder correctly', () => {
     const wrapper = mount(<DropdownButton placeholder='Select item' />)
-    expect(wrapper.find(`.${name}__item`).exists()).toEqual(true)
-    expect(wrapper.find(`.${name}__item`).contains('Number')).toEqual(false)
+    expect(wrapper.find(`.${name}__item`).exists()).toBe(true)
+    expect(wrapper.find(`.${name}__item`).contains('Number')).toBe(false)
     wrapper.unmount()
   })
 
   it('renders placeholder as value correctly', () => {
     const wrapper = mount(<DropdownButton value='apple' />)
-    expect(wrapper.find(`.${name}__item`).exists()).toEqual(true)
-    expect(wrapper.find(`.${name}__item`).contains('apple')).toEqual(true)
+    expect(wrapper.find(`.${name}__item`).exists()).toBe(true)
+    expect(wrapper.find(`.${name}__item`).contains('apple')).toBe(true)
     wrapper.unmount()
   })
 
   it('renders overflow set to truncate correctly', () => {
     const wrapper = mount(<DropdownButton overflow='truncate' items={[1, 3, 5]} />)
-    expect(wrapper.find(`.${name}__item`).exists()).toEqual(true)
-    expect(wrapper.find(`.${name}__item`).every(`.${name}__item--overflow-truncate`)).toEqual(true)
+    expect(wrapper.find(`.${name}__item`).exists()).toBe(true)
+    expect(wrapper.find(`.${name}__item`).every(`.${name}__item--overflow-truncate`)).toBe(true)
     wrapper.unmount()
   })
 
   it('renders overflow set to break correctly', () => {
     const wrapper = mount(<DropdownButton overflow='break' items={[1, 3, 5]} />)
-    expect(wrapper.find(`.${name}__item`).exists()).toEqual(true)
-    expect(wrapper.find(`.${name}__item`).every(`.${name}__item--overflow-break`)).toEqual(true)
+    expect(wrapper.find(`.${name}__item`).exists()).toBe(true)
+    expect(wrapper.find(`.${name}__item`).every(`.${name}__item--overflow-break`)).toBe(true)
     wrapper.unmount()
   })
 })

--- a/packages/combo-box/tests/Menu.test.js
+++ b/packages/combo-box/tests/Menu.test.js
@@ -15,15 +15,12 @@ describe('<Menu />', () => {
 
   it('renders highlighted item correctly', () => {
     const wrapper = mount(<Menu highlightedIndex={1} items={[1, 3, 5]} />)
-    const otherItem = wrapper
-      .find(`.${name}__item`)
-      .at(0)
-    const highlitedItem = wrapper
-      .find(`.${name}__item`)
-      .at(1)
 
-    expect(otherItem.hasClass(`${name}__item--highlighted`)).toEqual(false)
-    expect(highlitedItem.hasClass(`${name}__item--highlighted`)).toEqual(true)
+    const otherItem = wrapper.find(`.${name}__item`).at(0)
+    const highlitedItem = wrapper.find(`.${name}__item`).at(1)
+
+    expect(otherItem.hasClass(`${name}__item--highlighted`)).toBe(false)
+    expect(highlitedItem.hasClass(`${name}__item--highlighted`)).toBe(true)
     wrapper.unmount()
   })
 
@@ -36,32 +33,30 @@ describe('<Menu />', () => {
       .find(`.${name}__item`)
       .at(1)
 
-    expect(otherItem.hasClass(`${name}__item--selected`)
-    ).toEqual(false)
-    expect(highlitedItem.hasClass(`${name}__item--selected`)
-    ).toEqual(true)
+    expect(otherItem.hasClass(`${name}__item--selected`)).toBe(false)
+    expect(highlitedItem.hasClass(`${name}__item--selected`)).toBe(true)
     wrapper.unmount()
   })
 
   it('renders maxHeight correctly', () => {
     const wrapper = mount(<Menu maxHeight='200px' items={[1, 3, 5]} />)
 
-    expect(wrapper.find(`.${name}__options`).prop('style').maxHeight).toEqual('200px')
-    expect(wrapper.find(`.${name}__options`).prop('style').overflowY).toEqual('auto')
+    expect(wrapper.find(`.${name}__options`).prop('style').maxHeight).toBe('200px')
+    expect(wrapper.find(`.${name}__options`).prop('style').overflowY).toBe('auto')
     wrapper.unmount()
   })
 
   it('renders overflow set to truncate correctly', () => {
     const wrapper = mount(<Menu overflow='truncate' items={[1, 3, 5]} />)
 
-    expect(wrapper.find(`.${name}-item`).every(`.${name}__item--overflow-truncate`)).toEqual(true)
+    expect(wrapper.find(`.${name}-item`).every(`.${name}__item--overflow-truncate`)).toBe(true)
     wrapper.unmount()
   })
 
   it('renders overflow set to break correctly', () => {
     const wrapper = mount(<Menu overflow='break' items={[1, 3, 5]} />)
 
-    expect(wrapper.find(`.${name}-item`).every(`.${name}__item--overflow-break`)).toEqual(true)
+    expect(wrapper.find(`.${name}-item`).every(`.${name}__item--overflow-break`)).toBe(true)
     wrapper.unmount()
   })
 

--- a/packages/grid/tests/Group.test.js
+++ b/packages/grid/tests/Group.test.js
@@ -63,6 +63,6 @@ describe('<Group />', () => {
     )
 
     expect(wrapper.props().className).toMatch(/(^| )abc( |$)/)
-    expect(wrapper.props().className).not.toEqual('abc')
+    expect(wrapper.props().className).not.toBe('abc')
   })
 })

--- a/packages/grid/tests/Masonry.test.js
+++ b/packages/grid/tests/Masonry.test.js
@@ -61,6 +61,6 @@ describe('<Group />', () => {
     )
 
     expect(wrapper.props().className).toMatch(/(^| )abc( |$)/)
-    expect(wrapper.props().className).not.toEqual('abc')
+    expect(wrapper.props().className).not.toBe('abc')
   })
 })

--- a/packages/icon/tests/Icon.test.js
+++ b/packages/icon/tests/Icon.test.js
@@ -23,25 +23,25 @@ describe('<Icon />', () => {
     const wrapper = shallow(<Icon name={TALIXO_EXAMPLE} className='abc' />).dive()
 
     expect(wrapper.props().className).toMatch(/(^| )abc( |$)/)
-    expect(wrapper.props().className).not.toEqual('abc')
+    expect(wrapper.props().className).not.toBe('abc')
   })
 
   it('handles properly additional properties for Talixo icon', () => {
     const wrapper = shallow(<Icon name={TALIXO_EXAMPLE} id='def' className='abc' />)
 
-    expect(wrapper.props().id).toEqual('def')
+    expect(wrapper.props().id).toBe('def')
   })
 
   it('handles properly additional classes for Material icon', () => {
     const wrapper = shallow(<Icon name={MATERIAL_EXAMPLE} className='abc' />).dive()
 
     expect(wrapper.props().className).toMatch(/(^| )abc( |$)/)
-    expect(wrapper.props().className).not.toEqual('abc')
+    expect(wrapper.props().className).not.toBe('abc')
   })
 
   it('handles properly additional properties for Material icon', () => {
     const wrapper = shallow(<Icon name={MATERIAL_EXAMPLE} id='def' className='abc' />)
 
-    expect(wrapper.props().id).toEqual('def')
+    expect(wrapper.props().id).toBe('def')
   })
 })

--- a/packages/icon/tests/MaterialIcon.test.js
+++ b/packages/icon/tests/MaterialIcon.test.js
@@ -16,12 +16,12 @@ describe('<Icon />', () => {
     const wrapper = shallow(<Icon name={EXAMPLE} className='abc' />)
 
     expect(wrapper.props().className).toMatch(/(^| )abc( |$)/)
-    expect(wrapper.props().className).not.toEqual('abc')
+    expect(wrapper.props().className).not.toBe('abc')
   })
 
   it('handles properly additional properties for Material icon', () => {
     const wrapper = shallow(<Icon name={EXAMPLE} id='def' className='abc' />)
 
-    expect(wrapper.props().id).toEqual('def')
+    expect(wrapper.props().id).toBe('def')
   })
 })

--- a/packages/icon/tests/TalixoIcon.test.js
+++ b/packages/icon/tests/TalixoIcon.test.js
@@ -16,12 +16,12 @@ describe('<Icon />', () => {
     const wrapper = shallow(<Icon name={EXAMPLE} className='abc' />)
 
     expect(wrapper.props().className).toMatch(/(^| )abc( |$)/)
-    expect(wrapper.props().className).not.toEqual('abc')
+    expect(wrapper.props().className).not.toBe('abc')
   })
 
   it('handles properly additional properties for Material icon', () => {
     const wrapper = shallow(<Icon name={EXAMPLE} id='def' className='abc' />)
 
-    expect(wrapper.props().id).toEqual('def')
+    expect(wrapper.props().id).toBe('def')
   })
 })

--- a/packages/portal/tests/Portal.test.js
+++ b/packages/portal/tests/Portal.test.js
@@ -14,7 +14,7 @@ describe('<Portal />', () => {
     const wrapper = mount(<Portal />)
     const instance = wrapper.instance()
 
-    expect(instance.el.parentNode).toEqual(document.body)
+    expect(instance.el.parentNode).toBe(document.body)
   })
 
   it('should correctly attach to different element', () => {
@@ -23,8 +23,8 @@ describe('<Portal />', () => {
     const wrapper = mount(<Portal attachTo={element} />)
     const instance = wrapper.instance()
 
-    expect(instance.el.parentNode).toEqual(element)
-    expect(element.childNodes.length).toEqual(1)
+    expect(instance.el.parentNode).toBe(element)
+    expect(element.childNodes.length).toBe(1)
 
     wrapper.unmount()
   })
@@ -37,12 +37,12 @@ describe('<Portal />', () => {
 
     wrapper.setProps({ attachTo: undefined })
 
-    expect(instance.el.parentNode).toEqual(document.body)
+    expect(instance.el.parentNode).toBe(document.body)
 
     wrapper.setProps({ attachTo: element })
 
-    expect(instance.el.parentNode).toEqual(element)
-    expect(element.childNodes.length).toEqual(1)
+    expect(instance.el.parentNode).toBe(element)
+    expect(element.childNodes.length).toBe(1)
 
     wrapper.unmount()
   })
@@ -55,7 +55,7 @@ describe('<Portal />', () => {
 
     wrapper.unmount()
 
-    expect(instance.el.parentNode).toEqual(null)
-    expect(element.childNodes.length).toEqual(0)
+    expect(instance.el.parentNode).toBe(null)
+    expect(element.childNodes.length).toBe(0)
   })
 })

--- a/packages/shared/tests/applyAnyClassNameModifiers.test.js
+++ b/packages/shared/tests/applyAnyClassNameModifiers.test.js
@@ -5,17 +5,17 @@ const _ = config.prefix
 
 describe('@shared/applyAnyClassNameModifiers', () => {
   it('should apply single modifier to class', () => {
-    expect(applyAnyClassNameModifiers('abc', 'def')).toEqual(`${_}-abc--def`)
+    expect(applyAnyClassNameModifiers('abc', 'def')).toBe(`${_}-abc--def`)
   })
 
   it('should apply many modifiers to class', () => {
-    expect(applyAnyClassNameModifiers('abc', [ 'def', 'ghi' ])).toEqual(`${_}-abc--def ${_}-abc--ghi`)
+    expect(applyAnyClassNameModifiers('abc', [ 'def', 'ghi' ])).toBe(`${_}-abc--def ${_}-abc--ghi`)
   })
 
   it('should apply no modifiers to class', () => {
-    expect(applyAnyClassNameModifiers('abc')).toEqual('')
-    expect(applyAnyClassNameModifiers('abc', 0)).toEqual(`${_}-abc--0`)
-    expect(applyAnyClassNameModifiers('abc', false)).toEqual(`${_}-abc--false`)
+    expect(applyAnyClassNameModifiers('abc')).toBe('')
+    expect(applyAnyClassNameModifiers('abc', 0)).toBe(`${_}-abc--0`)
+    expect(applyAnyClassNameModifiers('abc', false)).toBe(`${_}-abc--false`)
   })
 
   it('should apply conditional modifiers', () => {
@@ -27,6 +27,6 @@ describe('@shared/applyAnyClassNameModifiers', () => {
       e: ''
     }
 
-    expect(applyAnyClassNameModifiers('abc', modifiers)).toEqual(`${_}-abc--a ${_}-abc--b`)
+    expect(applyAnyClassNameModifiers('abc', modifiers)).toBe(`${_}-abc--a ${_}-abc--b`)
   })
 })

--- a/packages/shared/tests/applyClassNameModifiers.test.js
+++ b/packages/shared/tests/applyClassNameModifiers.test.js
@@ -5,16 +5,16 @@ const _ = config.prefix
 
 describe('@shared/applyClassNameModifiers', () => {
   it('should apply single modifier to class', () => {
-    expect(applyClassNameModifiers('abc', 'def')).toEqual(`${_}-abc--def`)
+    expect(applyClassNameModifiers('abc', 'def')).toBe(`${_}-abc--def`)
   })
 
   it('should apply many modifiers to class', () => {
-    expect(applyClassNameModifiers('abc', [ 'def', 'ghi' ])).toEqual(`${_}-abc--def ${_}-abc--ghi`)
+    expect(applyClassNameModifiers('abc', [ 'def', 'ghi' ])).toBe(`${_}-abc--def ${_}-abc--ghi`)
   })
 
   it('should apply no modifiers to class', () => {
-    expect(applyClassNameModifiers('abc')).toEqual('')
-    expect(applyClassNameModifiers('abc', 0)).toEqual(`${_}-abc--0`)
-    expect(applyClassNameModifiers('abc', false)).toEqual(`${_}-abc--false`)
+    expect(applyClassNameModifiers('abc')).toBe('')
+    expect(applyClassNameModifiers('abc', 0)).toBe(`${_}-abc--0`)
+    expect(applyClassNameModifiers('abc', false)).toBe(`${_}-abc--false`)
   })
 })

--- a/packages/shared/tests/buildClassName.test.js
+++ b/packages/shared/tests/buildClassName.test.js
@@ -5,17 +5,17 @@ const _ = config.prefix
 
 describe('@shared/buildClassName', () => {
   it('should apply single modifier to class', () => {
-    expect(buildClassName('abc', null, 'def')).toEqual(`${_}-abc ${_}-abc--def`)
+    expect(buildClassName('abc', null, 'def')).toBe(`${_}-abc ${_}-abc--def`)
   })
 
   it('should apply many modifiers to class', () => {
-    expect(buildClassName('abc', null, [ 'def', 'ghi' ])).toEqual(`${_}-abc ${_}-abc--def ${_}-abc--ghi`)
+    expect(buildClassName('abc', null, [ 'def', 'ghi' ])).toBe(`${_}-abc ${_}-abc--def ${_}-abc--ghi`)
   })
 
   it('should apply no modifiers to class', () => {
-    expect(buildClassName('abc')).toEqual(`${_}-abc`)
-    expect(buildClassName('abc', null, 0)).toEqual(`${_}-abc ${_}-abc--0`)
-    expect(buildClassName('abc', null, false)).toEqual(`${_}-abc ${_}-abc--false`)
+    expect(buildClassName('abc')).toBe(`${_}-abc`)
+    expect(buildClassName('abc', null, 0)).toBe(`${_}-abc ${_}-abc--0`)
+    expect(buildClassName('abc', null, false)).toBe(`${_}-abc ${_}-abc--false`)
   })
 
   it('should apply conditional modifiers', () => {
@@ -27,7 +27,7 @@ describe('@shared/buildClassName', () => {
       e: ''
     }
 
-    expect(buildClassName('abc', null, modifiers)).toEqual(`${_}-abc ${_}-abc--a ${_}-abc--b`)
+    expect(buildClassName('abc', null, modifiers)).toBe(`${_}-abc ${_}-abc--a ${_}-abc--b`)
   })
 
   it('should allow additional class name', () => {
@@ -39,9 +39,9 @@ describe('@shared/buildClassName', () => {
       e: ''
     }
 
-    expect(buildClassName('abc', 'blabla', modifiers)).toEqual(`${_}-abc blabla ${_}-abc--a ${_}-abc--b`)
-    expect(buildClassName('abc', 'blabla', [ 'def', 'ghi' ])).toEqual(`${_}-abc blabla ${_}-abc--def ${_}-abc--ghi`)
-    expect(buildClassName('abc', 'blabla')).toEqual(`${_}-abc blabla`)
+    expect(buildClassName('abc', 'blabla', modifiers)).toBe(`${_}-abc blabla ${_}-abc--a ${_}-abc--b`)
+    expect(buildClassName('abc', 'blabla', [ 'def', 'ghi' ])).toBe(`${_}-abc blabla ${_}-abc--def ${_}-abc--ghi`)
+    expect(buildClassName('abc', 'blabla')).toBe(`${_}-abc blabla`)
   })
 
   it('should allow many modifiers', () => {
@@ -61,6 +61,6 @@ describe('@shared/buildClassName', () => {
       [ 'ghi', 'jkl' ]
     )
 
-    expect(className).toEqual(`${_}-abc blabla ${_}-abc--a ${_}-abc--b ${_}-abc--def ${_}-abc--ghi ${_}-abc--jkl`)
+    expect(className).toBe(`${_}-abc blabla ${_}-abc--a ${_}-abc--b ${_}-abc--def ${_}-abc--ghi ${_}-abc--jkl`)
   })
 })

--- a/packages/shared/tests/prefix.test.js
+++ b/packages/shared/tests/prefix.test.js
@@ -5,11 +5,11 @@ const _ = config.prefix
 
 describe('@shared/prefix', () => {
   it('should handle simple prefix correctly', () => {
-    expect(prefix('abc')).toEqual(`${_}-abc`)
-    expect(prefix('abc__def')).toEqual(`${_}-abc__def`)
+    expect(prefix('abc')).toBe(`${_}-abc`)
+    expect(prefix('abc__def')).toBe(`${_}-abc__def`)
   })
 
   it('should handle multi prefix correctly', () => {
-    expect(prefix('abc', 'def', 'ghi')).toEqual(`${_}-abc__def__ghi`)
+    expect(prefix('abc', 'def', 'ghi')).toBe(`${_}-abc__def__ghi`)
   })
 })

--- a/packages/sidebar/src/Sidebar.js
+++ b/packages/sidebar/src/Sidebar.js
@@ -3,8 +3,6 @@ import PropTypes from 'prop-types'
 
 import { prefix, buildClassName } from '@talixo/shared'
 
-const moduleName = prefix('sidebar')
-
 /**
  * Component which represents Sidebar.
  *
@@ -18,7 +16,7 @@ function Sidebar (props) {
 
   return (
     <nav className={buildClassName('sidebar', className)} {...passedProps}>
-      <div className={`${moduleName}__content`}>
+      <div className={prefix('sidebar', 'content')}>
         {children}
       </div>
     </nav>

--- a/packages/sidebar/src/SidebarElement.js
+++ b/packages/sidebar/src/SidebarElement.js
@@ -5,8 +5,6 @@ import { prefix, buildClassName } from '@talixo/shared'
 
 import { Icon } from '@talixo/icon'
 
-const moduleName = prefix('sidebar-element')
-
 /**
  * Component which represents sidebar element,
  * which can be also opened.
@@ -19,7 +17,7 @@ const moduleName = prefix('sidebar-element')
  * @property {boolean} props.active
  *
  * @property {object} state
- * @property {boolean} state.isOpen
+ * @property {boolean} state.open
  *
  * @property {Element} node  reference to DOM element of Sidebar
  *
@@ -35,7 +33,7 @@ class SidebarElement extends React.PureComponent {
 
     this.node = null
     this.state = {
-      isOpen: false
+      open: false
     }
   }
 
@@ -85,7 +83,7 @@ class SidebarElement extends React.PureComponent {
     }
 
     // Close current sidebar if it was clicked outside
-    this.setState({ isOpen: false })
+    this.setState({ open: false })
 
     // Detach events to not listen on it without reason
     this.detachListener()
@@ -100,13 +98,13 @@ class SidebarElement extends React.PureComponent {
   handleClick (e) {
     const { children, onClick } = this.props
 
-    // Toggle opening status when it could be isOpen
+    // Toggle opening status when it could be open
     if (children) {
-      const isOpen = !this.state.isOpen
+      const open = !this.state.open
 
-      this.setState({ isOpen: isOpen })
+      this.setState({ open: open })
 
-      if (isOpen) {
+      if (open) {
         this.attachListener()
       } else {
         this.detachListener()
@@ -152,20 +150,17 @@ class SidebarElement extends React.PureComponent {
 
   render () {
     const { className, icon, label, active, children, onClick, ...passedProps } = this.props
-    const { isOpen } = this.state
+    const { open } = this.state
 
     // Build class name with modifiers according to current state
-    const clsName = buildClassName('sidebar-element', className, {
-      active: active,
-      open: isOpen
-    })
+    const clsName = buildClassName('sidebar-element', className, { active, open })
 
     // Check if we do have single children inside
     const element = children ? React.Children.only(children) : null
 
     // Build button
     const button = (
-      <div className={`${moduleName}__button`} onClick={this.handleClick}>
+      <div className={prefix('sidebar-element', 'button')} onClick={this.handleClick}>
         <Icon name={icon} />
         {label}
       </div>

--- a/packages/sidebar/src/SidebarPanel.js
+++ b/packages/sidebar/src/SidebarPanel.js
@@ -5,8 +5,6 @@ import { prefix, buildClassName } from '@talixo/shared'
 
 import { Icon } from '@talixo/icon'
 
-const moduleName = prefix('sidebar-panel')
-
 /**
  * Component which represents Sidebar.
  *
@@ -25,7 +23,7 @@ function SidebarPanel (props) {
 
   // Build header if panel has its name
   const header = name ? (
-    <h2 className={`${moduleName}__header`}>
+    <h2 className={prefix('sidebar-panel', 'header')}>
       <Icon name={icon} />
       <span>{name}</span>
     </h2>
@@ -33,7 +31,7 @@ function SidebarPanel (props) {
 
   return (
     <div className={clsName} {...passedProps}>
-      <div className={`${moduleName}__content`}>
+      <div className={prefix('sidebar-panel', 'content')}>
         {header}
         {children}
       </div>

--- a/packages/sidebar/tests/Sidebar.test.js
+++ b/packages/sidebar/tests/Sidebar.test.js
@@ -4,9 +4,26 @@ import { shallow } from 'enzyme'
 import Sidebar from '../src/Sidebar'
 
 describe('<Sidebar />', () => {
-  it('renders children correctly', () => {
+  it('renders empty sidebar correctly', () => {
     const wrapper = shallow(<Sidebar />)
 
     expect(wrapper).toMatchSnapshot()
+  })
+
+  it('should pass class name correctly', () => {
+    const wrapper = shallow(
+      <Sidebar className='blabla' />
+    )
+
+    expect(wrapper.hasClass('blabla')).toBeTruthy()
+    expect(wrapper.hasClass('talixo-sidebar')).toBeTruthy()
+  })
+
+  it('should pass other attributes correctly', () => {
+    const wrapper = shallow(
+      <Sidebar role='navigation' />
+    )
+
+    expect(wrapper.props().role).toBe('navigation')
   })
 })

--- a/packages/sidebar/tests/SidebarElement.test.js
+++ b/packages/sidebar/tests/SidebarElement.test.js
@@ -1,7 +1,8 @@
 import React from 'react'
-import { shallow } from 'enzyme'
+import { shallow, mount } from 'enzyme'
 
 import SidebarElement from '../src/SidebarElement'
+import SidebarPanel from '../src/SidebarPanel'
 
 describe('<SidebarElement />', () => {
   it('renders children correctly', () => {
@@ -13,5 +14,131 @@ describe('<SidebarElement />', () => {
     )
 
     expect(wrapper).toMatchSnapshot()
+  })
+
+  it('should handle simple click on button', () => {
+    const click = jest.fn()
+
+    const wrapper = shallow(
+      <SidebarElement
+        icon='home'
+        label='See more'
+        onClick={click}
+      />
+    )
+
+    wrapper.find('.talixo-sidebar-element__button').simulate('click')
+
+    expect(click.mock.calls.length).toBe(1)
+  })
+
+  it('should render properly with panel inside', () => {
+    const wrapper = shallow(
+      <SidebarElement icon='home' label='See more'>
+        <SidebarPanel>content</SidebarPanel>
+      </SidebarElement>
+    )
+
+    expect(wrapper).toMatchSnapshot()
+  })
+
+  it('should open with panel inside', () => {
+    const click = jest.fn()
+
+    const wrapper = mount(
+      <SidebarElement icon='home' label='See more' onClick={click}>
+        <SidebarPanel>content</SidebarPanel>
+      </SidebarElement>
+    )
+
+    wrapper.find('.talixo-sidebar-element__button').simulate('click')
+
+    expect(click.mock.calls.length).toBe(1)
+    expect(wrapper.instance().state.open).toBe(true)
+
+    wrapper.unmount()
+  })
+
+  it('should open and close on double click', () => {
+    const click = jest.fn()
+
+    const wrapper = mount(
+      <SidebarElement icon='home' label='See more' onClick={click}>
+        <SidebarPanel>content</SidebarPanel>
+      </SidebarElement>
+    )
+
+    wrapper.find('.talixo-sidebar-element__button')
+      .simulate('click')
+      .simulate('click')
+
+    expect(click.mock.calls.length).toBe(2)
+    expect(wrapper.instance().state.open).toBe(false)
+
+    wrapper.unmount()
+  })
+
+  it('should not close on click anywhere inside element', () => {
+    const wrapper = mount(
+      <SidebarElement icon='home' label='See more'>
+        <SidebarPanel>content</SidebarPanel>
+      </SidebarElement>
+    )
+
+    wrapper.find('.talixo-sidebar-element__button').simulate('click')
+
+    wrapper.simulate('click')
+
+    expect(wrapper.instance().state.open).toBe(true)
+
+    wrapper.unmount()
+  })
+
+  it('should close on click anywhere outside element', () => {
+    const wrapper = mount(
+      <SidebarElement icon='home' label='See more'>
+        <SidebarPanel>content</SidebarPanel>
+      </SidebarElement>
+    )
+
+    document.documentElement.dispatchEvent(new window.Event('click'))
+
+    expect(wrapper.instance().state.open).toBe(false)
+
+    wrapper.unmount()
+  })
+
+  it('should not close when handleClose is fired within element', () => {
+    const wrapper = mount(
+      <SidebarElement icon='home' label='See more'>
+        <SidebarPanel>content</SidebarPanel>
+      </SidebarElement>
+    )
+
+    wrapper.find('.talixo-sidebar-element__button').simulate('click')
+
+    const instance = wrapper.instance()
+    instance.handleClose({ target: instance.node })
+
+    expect(wrapper.instance().state.open).toBe(true)
+
+    wrapper.unmount()
+  })
+
+  it('should close when handleClose is fired outside element', () => {
+    const wrapper = mount(
+      <SidebarElement icon='home' label='See more'>
+        <SidebarPanel>content</SidebarPanel>
+      </SidebarElement>
+    )
+
+    wrapper.find('.talixo-sidebar-element__button').simulate('click')
+
+    const instance = wrapper.instance()
+    instance.handleClose({ target: document.body })
+
+    expect(wrapper.instance().state.open).toBe(false)
+
+    wrapper.unmount()
   })
 })

--- a/packages/sidebar/tests/SidebarPanel.test.js
+++ b/packages/sidebar/tests/SidebarPanel.test.js
@@ -4,9 +4,48 @@ import { shallow } from 'enzyme'
 import SidebarPanel from '../src/SidebarPanel'
 
 describe('<SidebarPanel />', () => {
-  it('renders children correctly', () => {
+  it('renders empty correctly', () => {
     const wrapper = shallow(<SidebarPanel />)
 
     expect(wrapper).toMatchSnapshot()
+  })
+
+  it('renders with header and icon correctly', () => {
+    const wrapper = shallow(
+      <SidebarPanel icon='settings' name='Something' />
+    )
+
+    expect(wrapper).toMatchSnapshot()
+  })
+
+  it('renders with header and content correctly', () => {
+    const wrapper = shallow(
+      <SidebarPanel icon='settings' name='Something'>
+        There is some content
+      </SidebarPanel>
+    )
+
+    expect(wrapper).toMatchSnapshot()
+  })
+
+  it('should pass class name correctly', () => {
+    const wrapper = shallow(
+      <SidebarPanel className='blabla'>
+        There is some content
+      </SidebarPanel>
+    )
+
+    expect(wrapper.hasClass('blabla')).toBeTruthy()
+    expect(wrapper.hasClass('talixo-sidebar-panel')).toBeTruthy()
+  })
+
+  it('should pass other attributes correctly', () => {
+    const wrapper = shallow(
+      <SidebarPanel role='navigation'>
+        There is some content
+      </SidebarPanel>
+    )
+
+    expect(wrapper.props().role).toBe('navigation')
   })
 })

--- a/packages/sidebar/tests/__snapshots__/Sidebar.test.js.snap
+++ b/packages/sidebar/tests/__snapshots__/Sidebar.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<Sidebar /> renders children correctly 1`] = `
+exports[`<Sidebar /> renders empty sidebar correctly 1`] = `
 <nav
   className="talixo-sidebar"
 >

--- a/packages/sidebar/tests/__snapshots__/SidebarElement.test.js.snap
+++ b/packages/sidebar/tests/__snapshots__/SidebarElement.test.js.snap
@@ -15,3 +15,22 @@ exports[`<SidebarElement /> renders children correctly 1`] = `
   </div>
 </div>
 `;
+
+exports[`<SidebarElement /> should render properly with panel inside 1`] = `
+<div
+  className="talixo-sidebar-element"
+>
+  <div
+    className="talixo-sidebar-element__button"
+    onClick={[Function]}
+  >
+    <Icon
+      name="home"
+    />
+    See more
+  </div>
+  <SidebarPanel>
+    content
+  </SidebarPanel>
+</div>
+`;

--- a/packages/sidebar/tests/__snapshots__/SidebarPanel.test.js.snap
+++ b/packages/sidebar/tests/__snapshots__/SidebarPanel.test.js.snap
@@ -1,11 +1,54 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<SidebarPanel /> renders children correctly 1`] = `
+exports[`<SidebarPanel /> renders empty correctly 1`] = `
 <div
   className="talixo-sidebar-panel"
 >
   <div
     className="talixo-sidebar-panel__content"
   />
+</div>
+`;
+
+exports[`<SidebarPanel /> renders with header and content correctly 1`] = `
+<div
+  className="talixo-sidebar-panel"
+>
+  <div
+    className="talixo-sidebar-panel__content"
+  >
+    <h2
+      className="talixo-sidebar-panel__header"
+    >
+      <Icon
+        name="settings"
+      />
+      <span>
+        Something
+      </span>
+    </h2>
+    There is some content
+  </div>
+</div>
+`;
+
+exports[`<SidebarPanel /> renders with header and icon correctly 1`] = `
+<div
+  className="talixo-sidebar-panel"
+>
+  <div
+    className="talixo-sidebar-panel__content"
+  >
+    <h2
+      className="talixo-sidebar-panel__header"
+    >
+      <Icon
+        name="settings"
+      />
+      <span>
+        Something
+      </span>
+    </h2>
+  </div>
 </div>
 `;

--- a/packages/text-input/tests/TextInput.test.js
+++ b/packages/text-input/tests/TextInput.test.js
@@ -65,7 +65,7 @@ describe('<TextInput />', () => {
     })
 
     it('should update state', () => {
-      expect(wrapper.state().inputValue).toEqual('Test')
+      expect(wrapper.state().inputValue).toBe('Test')
     })
 
     it(`should add .${`${moduleName}__label--not-empty`} to label`, () => {

--- a/packages/tooltip/tests/Tooltip.test.js
+++ b/packages/tooltip/tests/Tooltip.test.js
@@ -25,7 +25,7 @@ describe('<Tooltip />', () => {
     )
     wrapper.find(`.${name}-target`).simulate('mouseOver')
 
-    expect(wrapper.contains(<span>Left</span>)).toEqual(true)
+    expect(wrapper.contains(<span>Left</span>)).toBe(true)
     wrapper.unmount()
   })
 
@@ -37,7 +37,7 @@ describe('<Tooltip />', () => {
     )
     wrapper.find(`.${name}-target`).simulate('mouseOver')
 
-    expect(wrapper.find(`.${name}`).hasClass(`${name}--top`)).toEqual(true)
+    expect(wrapper.find(`.${name}`).hasClass(`${name}--top`)).toBe(true)
     wrapper.unmount()
   })
 
@@ -49,7 +49,7 @@ describe('<Tooltip />', () => {
     )
     wrapper.find(`.${name}-target`).simulate('mouseOver')
 
-    expect(wrapper.find(`.${name}`).hasClass('big')).toEqual(true)
+    expect(wrapper.find(`.${name}`).hasClass('big')).toBe(true)
     wrapper.unmount()
   })
 
@@ -84,7 +84,7 @@ describe('<Tooltip />', () => {
       </Tooltip>
     )
 
-    expect(wrapper.contains(<span>Left</span>)).toEqual(true)
+    expect(wrapper.contains(<span>Left</span>)).toBe(true)
     wrapper.unmount()
   })
 
@@ -96,7 +96,7 @@ describe('<Tooltip />', () => {
     )
     wrapper.find(`.${name}-target`).simulate('click')
 
-    expect(wrapper.contains(<span>Left</span>)).toEqual(true)
+    expect(wrapper.contains(<span>Left</span>)).toBe(true)
     wrapper.unmount()
   })
 


### PR DESCRIPTION
#### Task

- **Issue or task referred:** UI-13
- **Feature or Bugfix:** Feature

Added unit tests for Sidebar. Additionally, I changed `toEqual` to `toBe` when it was possible, to not check deep when it's not needed.

Unit tests before on CI: 28s
Unit tests now on CI: 22s

While we will be adding more tests, difference may be bigger.

#### Checklist

- [x] Required unit tests prepared
- [x] Documentation prepared
- [x] External licenses validated (ideally MIT)
