### PR TITLE
Bundle external packages correctly inside our packages

### DIFF
--- a/scripts/buildPackages.js
+++ b/scripts/buildPackages.js
@@ -37,7 +37,7 @@ async function buildPackage (pack, environment) {
   // Build basic Rollup.js configuration
   const config = {
     input: pack.input,
-    external: pack.dependencies,
+    external: id => !!pack.dependencies.find(dependency => dependency === id || id.startsWith(dependency + '/')),
     output: {
       file: pack.output[environment],
       exports: 'named',


### PR DESCRIPTION
#### Task

- **Feature or Bugfix:** Bugfix

There were problems with bundling external package inside ours:

- We had a plain list of dependencies from `package.json` - when we had `react-dates` dependency it was resolving `react-dates` correctly as external, but `react-dates/initialize` was bundled inside
- Our packages are symlinked between themselves, so Rollup was finding out that it's in `packages/something-else/index.js` file, so it wasn't treated as external dependency - it was bundled inside.
