### PR TITLE
[UI-62] Expanding rows in tables

### DIFF
--- a/packages/data-table/README.md
+++ b/packages/data-table/README.md
@@ -26,18 +26,21 @@ to avoid having different versions of these in your application.
 
 It allows any props which are allowed for `Table` omponent from `@talixo/table`. Additionally, it handles some differently:
 
-Property name       | Type      | Required  | Default | Description                    
---------------------|-----------|-----------|:-------:|--------------------------------
-actions             | Actions[] | no        | n/a     | Actions which can be applied to rows.
-className           | string    | no        | n/a     | Additional class name passed to wrapper.
-columns             | Column[]  | yes       | n/a     | Information about columns which will be displayed in table.
-data                | object[]  | yes       | n/a     | Data to be populated inside table. Require the same keys as inc olumns objects.
-expandRender        | function  | no        | n/a     | Render function of items which will be displayed in table collapsible rows.
-expandedRows        | array     | no        | n/a     | Array should contain IDs of expanded rows. Its elements should be `id` properties of data items (if provided) or indexes of elements in data array.
-onClick             | function  | no        | n/a     | Row onClick callback function.
-onSort              | function  | no        | n/a     | onSort function callback.
-sortable            | boolean   | no        |`false`  | Indicates if table is sortable.
-verticalActionCell  | string    | no        | n/a     | Indicates if actions should be displayed vertically or horizontally.
+Property name       | Type      | Required  | Default           | Description                    
+--------------------|-----------|-----------|:-----------------:|--------------------------------
+actions             | Actions[] | no        | n/a               | Actions which can be applied to rows.
+buildId             | function  | no        | `(row, idx) => row.id` | Function which will be used to add ID to object items if these are not already inside them.
+className           | string    | no        | n/a               | Additional class name passed to wrapper.
+columns             | Column[]  | yes       | n/a               | Information about columns which will be displayed in table.
+data                | object[]  | yes       | n/a               | Data to be populated inside table. Require the same keys as inc olumns objects.
+expandRender        | function  | no        | n/a               | Render function of items which will be displayed in table collapsible rows.
+expandedRows        | array     | no        | n/a               | Array should contain IDs of expanded rows. Its elements should be `id` properties of data items (if provided) or indexes of elements in data array.
+onClick             | function  | no        | n/a               | Row onClick callback function.
+onSort              | function  | no        | n/a               | onSort function callback.
+sortable            | boolean   | no        | `false`           | Indicates if table is sortable.
+sortColumn          | string    | no        | self-constrolled  | ID of the column according to which data is sorted.
+reversedOrder       | boolean   | no        | self-constrolled  | Indicates if table is sortable.
+verticalActionCell  | string    | no        | n/a               | Indicates if actions should be displayed vertically or horizontally.
 
 ## Property shapes
 

--- a/packages/data-table/README.md
+++ b/packages/data-table/README.md
@@ -28,12 +28,15 @@ It allows any props which are allowed for `Table` omponent from `@talixo/table`.
 
 Property name       | Type      | Required  | Default | Description                    
 --------------------|-----------|-----------|:-------:|--------------------------------
+actions             | Actions[] | no        | n/a     | Actions which can be applied to rows.
 className           | string    | no        | n/a     | Additional class name passed to wrapper.
 columns             | Column[]  | yes       | n/a     | Information about columns which will be displayed in table.
 data                | object[]  | yes       | n/a     | Data to be populated inside table. Require the same keys as inc olumns objects.
+expandRender        | function  | no        | n/a     | Render function of items which will be displayed in table collapsible rows.
+expandedRows        | array     | no        | n/a     | Array should contain IDs of expanded rows. Its elements should be `id` properties of data items (if provided) or indexes of elements in data array.
+onClick             | function  | no        | n/a     | Row onClick callback function.
 onSort              | function  | no        | n/a     | onSort function callback.
 sortable            | boolean   | no        |`false`  | Indicates if table is sortable.
-actions             | Actions[] | no        | n/a     | Actions which can be applied to rows.
 verticalActionCell  | string    | no        | n/a     | Indicates if actions should be displayed vertically or horizontally.
 
 ## Property shapes

--- a/packages/data-table/package.json
+++ b/packages/data-table/package.json
@@ -24,6 +24,7 @@
   "license": "MIT",
   "devDependencies": {
     "@talixo/icon": "^0.1.1",
+    "@talixo/notification": "^0.1.0",
     "@talixo/shared": "^0.1.0",
     "@talixo/table": "^0.1.0",
     "lodash": "^4.17.10",

--- a/packages/data-table/src/DataTable.js
+++ b/packages/data-table/src/DataTable.js
@@ -11,6 +11,23 @@ import TableRow from './TableRow'
 import { moduleName } from './config'
 
 const propTypes = {
+  /** Actions which can be applied to rows. */
+  actions: PropTypes.arrayOf(PropTypes.shape({
+
+    /** Function which indicates if button should be displayed.
+     * Assigns item from data as function argument. */
+    condition: PropTypes.func,
+
+    /** Button icon name from `@talixo/icon` package. */
+    icon: PropTypes.string.isRequired,
+
+    /** Button label. */
+    label: PropTypes.string.isRequired,
+
+    /** onClick callback function. */
+    onClick: PropTypes.func
+  })),
+
   /** Additional class name. */
   className: PropTypes.string,
 
@@ -33,28 +50,20 @@ const propTypes = {
   /** Data to be populated inside table. Require the same keys as in columns objects. */
   data: PropTypes.arrayOf(PropTypes.object).isRequired,
 
+  /** Render function of items which will be displayed in table collapsible rows. */
+  expandRender: PropTypes.func,
+
+  /** Array should contain IDs of expanded rows. Its elements should be `id` properties of data items (if provided) or indexes of elements in data array. */
+  expandedRows: PropTypes.array,
+
+  /** Row onClick callback function. */
+  onClick: PropTypes.func,
+
   /** onSort function callback. */
   onSort: PropTypes.func,
 
   /** Indicates if table is sortable. */
   sortable: PropTypes.bool,
-
-  /** Actions which can be applied to rows. */
-  actions: PropTypes.arrayOf(PropTypes.shape({
-
-    /** Function which indicates if button should be displayed.
-     * Assigns item from data as function argument. */
-    condition: PropTypes.func,
-
-    /** Button icon name from `@talixo/icon` package. */
-    icon: PropTypes.string.isRequired,
-
-    /** Button label. */
-    label: PropTypes.string.isRequired,
-
-    /** onClick callback function. */
-    onClick: PropTypes.func
-  })),
 
   /** Indicates if actions should be displayed vertically or horizontally. */
   verticalActionCell: PropTypes.bool
@@ -64,7 +73,7 @@ const defaultProps = {
   sortable: false
 }
 
-function checkForId (collection) {
+export function checkForId (collection) {
   const keys = Object.keys(collection[0])
   const hasId = keys.indexOf('id') > -1
   if (hasId) {
@@ -80,6 +89,11 @@ function checkForId (collection) {
  * Component which represents DataTable.
  *
  * @property {object} props
+ * @property {object[]} [props.actions]
+ * @property {function} [props.actions.condition]
+ * @property {string} props.actions.icon
+ * @property {string} props.actions.label
+ * @property {function} [props.actions.onClick]
  * @property {string} [props.className]
  * @property {object[]} props.columns
  * @property {string|number} props.columns.id
@@ -87,18 +101,16 @@ function checkForId (collection) {
  * @property {function} [props.columns.render]
  * @property {function} [props.columns.renderHeader]
  * @property {object} props.data
+ * @property {object} [props.expandRender]
+ * @property {array} [props.expandedRows]
+ * @property {function} [props.onClick]
  * @property {function} [props.onSort]
  * @property {boolean} [props.sortable]
- * @property {object[]} [props.actions]
- * @property {function} [props.actions.condition]
- * @property {string} props.actions.icon
- * @property {string} props.actions.label
- * @property {function} [props.actions.onClick]
  * @property {boolean} [props.verticalActionCell]
  *
  * @property {object} state
  * @property {object} state.sortedData
- * @property {object} state.sortColumn - the column that is used in sortin process
+ * @property {object} state.sortColumn - the column that is used in sorting process
  * @property {object} state.reversedOrder - indicates if sorting should be descending
  *
  * @class
@@ -163,8 +175,8 @@ class DataTable extends React.Component {
 
   render (props) {
     const {
-      actions, expandRender, columns, className, data, onSort,
-      sortable, verticalActionCell, ...passedProps
+      actions, columns, className, expandRender, expandedRows, data,
+      onClick, onSort, sortable, verticalActionCell, ...passedProps
     } = this.props
     const { sortedData } = this.state
     const { buildHeaders } = this
@@ -179,7 +191,9 @@ class DataTable extends React.Component {
             actions={actions}
             columns={columns}
             expandRender={expandRender}
+            expandedRows={expandedRows}
             rowData={sortedData}
+            onClick={onClick}
             verticalActionCell={verticalActionCell}
           />
         </Body>

--- a/packages/data-table/src/DataTable.js
+++ b/packages/data-table/src/DataTable.js
@@ -30,7 +30,7 @@ const propTypes = {
     renderHeader: PropTypes.func
   })).isRequired,
 
-  /** Data to be populated inside table. Require the same keys as inc olumns objects. */
+  /** Data to be populated inside table. Require the same keys as in columns objects. */
   data: PropTypes.arrayOf(PropTypes.object).isRequired,
 
   /** onSort function callback. */
@@ -64,6 +64,18 @@ const defaultProps = {
   sortable: false
 }
 
+function checkForId (collection) {
+  const keys = Object.keys(collection[0])
+  const hasId = keys.indexOf('id') > -1
+  if (hasId) {
+    return collection
+  }
+  return collection.map((item, index) => ({
+    id: index,
+    ...item
+  }))
+}
+
 /**
  * Component which represents DataTable.
  *
@@ -93,7 +105,7 @@ const defaultProps = {
  */
 class DataTable extends React.Component {
   state = {
-    sortedData: this.props.data,
+    sortedData: checkForId(this.props.data),
     sortColumn: '',
     reversedOrder: false
   }
@@ -111,7 +123,7 @@ class DataTable extends React.Component {
     const _reversedOrder = sortColumn === columnID ? !reversedOrder : false
     // Set direction of sorting.
     const direction = !_reversedOrder ? 'asc' : 'desc'
-    // Oreder data using lodash sort funciton.
+    // Oreder data using lodash sort function.
     const newData = _.orderBy(sortedData, columnID, direction)
 
     this.setState({
@@ -131,7 +143,7 @@ class DataTable extends React.Component {
    * @returns {React.Element}
    */
   buildHeaders = () => {
-    const { columns, sortable } = this.props
+    const { columns, onSort, sortable } = this.props
     const { sortColumn, reversedOrder } = this.state
     const { sort } = this
     // Pass sorting order to allow propper sorting arrow hightlight.
@@ -139,7 +151,7 @@ class DataTable extends React.Component {
 
     const headersProps = {
       columns: columns,
-      onClick: (sortable && sort) || undefined,
+      onClick: (sortable && sort) || onSort || undefined,
       sortable: sortable,
       sortColumn: sortColumn,
       sortOrder: sortOrder
@@ -151,7 +163,7 @@ class DataTable extends React.Component {
 
   render (props) {
     const {
-      actions, columns, className, data, onSort,
+      actions, expandRender, columns, className, data, onSort,
       sortable, verticalActionCell, ...passedProps
     } = this.props
     const { sortedData } = this.state
@@ -166,6 +178,7 @@ class DataTable extends React.Component {
           <TableRow
             actions={actions}
             columns={columns}
+            expandRender={expandRender}
             rowData={sortedData}
             verticalActionCell={verticalActionCell}
           />

--- a/packages/data-table/stories.js
+++ b/packages/data-table/stories.js
@@ -3,6 +3,7 @@ import { action } from '@storybook/addon-actions'
 
 import { createStoriesFactory, getReadmeDescription } from '@talixo/shared/story'
 import { Icon } from '@talixo/icon'
+import { Notification } from '@talixo/notification'
 
 import DataTable from './src/DataTable'
 
@@ -17,22 +18,14 @@ const addStory = createStoriesFactory('DataTable', module, {
 // Mocks
 // Mock data
 const tableData = [
-  {
-    id: 0, opened: '17th Jan 2018', date_of_ride: '19th Feb 2018', assignee: 'Donald Truck', pickup: 'Krakow' },
-  {
-    id: 1, opened: '16th Jan 2018', date_of_ride: '18th Feb 2018', assignee: 'John Smith', pickup: 'Berlin' },
-  {
-    id: 2, opened: '18th Jan 2018', date_of_ride: '20th Feb 2018', assignee: 'Matthew McMouse', pickup: 'Warszawa' },
-  {
-    id: 3, opened: '19th Jan 2018', date_of_ride: '21th Feb 2018', assignee: 'Andrew Planet', pickup: 'Frankfurt' },
-  {
-    id: 4, opened: '20th Jan 2018', date_of_ride: '22th Feb 2018', assignee: 'Drew Drew', pickup: 'Dortmund' },
-  {
-    id: 5, opened: '21th Jan 2018', date_of_ride: '23th Feb 2018', assignee: 'John Bull', pickup: 'Paris' },
-  {
-    id: 6, opened: '22th Jan 2018', date_of_ride: '24th Feb 2018', assignee: 'Josh Josh', pickup: 'Barcelona' },
-  {
-    id: 7, opened: '23th Jan 2018', date_of_ride: '25th Feb 2018', assignee: 'John Smith', pickup: 'London' }
+  { id: 0, opened: '17th Jan 2018', date_of_ride: '19th Feb 2018', assignee: 'Donald Truck', pickup: 'Krakow' },
+  { id: 1, opened: '16th Jan 2018', date_of_ride: '18th Feb 2018', assignee: 'John Smith', pickup: 'Berlin' },
+  { id: 2, opened: '18th Jan 2018', date_of_ride: '20th Feb 2018', assignee: 'Matthew McMouse', pickup: 'Warszawa' },
+  { id: 3, opened: '19th Jan 2018', date_of_ride: '21th Feb 2018', assignee: 'Andrew Planet', pickup: 'Frankfurt' },
+  { id: 4, opened: '20th Jan 2018', date_of_ride: '22th Feb 2018', assignee: 'Drew Drew', pickup: 'Dortmund' },
+  { id: 5, opened: '21th Jan 2018', date_of_ride: '23th Feb 2018', assignee: 'John Bull', pickup: 'Paris' },
+  { id: 6, opened: '22th Jan 2018', date_of_ride: '24th Feb 2018', assignee: 'Josh Josh', pickup: 'Barcelona' },
+  { id: 7, opened: '23th Jan 2018', date_of_ride: '25th Feb 2018', assignee: 'John Smith', pickup: 'London' }
 ]
 
 const tableDataNoAssignee = [
@@ -44,6 +37,16 @@ const tableDataNoAssignee = [
   { id: 5, opened: '21th Jan 2018', date_of_ride: '23th Feb 2018', assignee: 'John Bull', pickup: 'Paris' },
   { id: 6, opened: '22th Jan 2018', date_of_ride: '24th Feb 2018', assignee: '', pickup: 'Barcelona' },
   { id: 7, opened: '23th Jan 2018', date_of_ride: '25th Feb 2018', assignee: 'John Smith', pickup: 'London' }
+]
+
+const tableDataCollapse = [
+  { id: 0, opened: '17th Jan 2018', date_of_ride: '19th Feb 2018', assignee: 'Donald Truck', pickup: 'Krakow', info: { name: 'Josh Smith', value: '0.00', rank: 'Private', abb: 'PVT', phone: '987 654 13232' } },
+  { id: 1, opened: '16th Jan 2018', date_of_ride: '18th Feb 2018', assignee: 'John Smith', pickup: 'Berlin', info: { name: 'Josh Smith I', value: '1.00', rank: 'Private Second Class', abb: 'PV2', phone: '987 654 13232' } },
+  { id: 2, opened: '18th Jan 2018', date_of_ride: '20th Feb 2018', assignee: 'Matthew McMouse', pickup: 'Warszawa', info: { name: 'Josh Smith II', value: '11.00', rank: 'Private First Class', abb: 'PFC', phone: '987 654 13232' } },
+  { id: 3, opened: '19th Jan 2018', date_of_ride: '21th Feb 2018', assignee: 'Andrew Planet', pickup: 'Frankfurt', info: { name: 'Josh Smith III', value: '22.00', rank: 'Specialist', abb: 'SPC', phone: '987 654 13232' } },
+  { id: 4, opened: '20th Jan 2018', date_of_ride: '22th Feb 2018', assignee: 'Drew Drew', pickup: 'Dortmund', info: { name: 'Josh Smith IV', value: '33.00', rank: 'Corporal', abb: 'CPL', phone: '987 654 13232' } },
+  { id: 5, opened: '21th Jan 2018', date_of_ride: '23th Feb 2018', assignee: 'John Bull', pickup: 'Paris', info: { name: 'Josh Smith V', value: '44.00', rank: 'Sergeant', abb: 'SGT', phone: '987 654 13232' } },
+  { id: 6, opened: '22th Jan 2018', date_of_ride: '24th Feb 2018', assignee: 'Josh Josh', pickup: 'Barcelona', info: { name: 'Josh Smith VI', value: '55.00', rank: 'Staff Sergeant', abb: 'SSG', phone: '987 654 13232' } }
 ]
 
 // Mock columns
@@ -96,8 +99,15 @@ const actionsConditional = [
 
 // Mock expand render
 function expandRender (item) {
+  const { info } = item
   return (
-    <div>{item.id} {item.opened} {item.assignee} </div>
+    <div className='storybook-data-table'>
+      <div className='storybook-data-table__item'>Passenger details:</div>
+      <div className='storybook-data-table__item'><Icon name='avatar' /> {info.name}</div>
+      <div className='storybook-data-table__item'><Icon name='attach_money' /> {info.value}</div>
+      <div className='storybook-data-table__item'><Icon name='assessment' /> {info.rank} ({info.abb})</div>
+      <div className='storybook-data-table__item'><Icon name='phone' /> {info.phone}</div>
+    </div>
   )
 }
 
@@ -163,12 +173,40 @@ addStory('custom headers', readme, () => (
   />
 ))
 
+addStory.controlled('clickable row', readme, (setState, state) => (
+  <div>
+    <DataTable
+      actions={actions}
+      columns={columnsCustomHeaders}
+      data={tableData}
+      onClick={(item) => setState({ notify: item })}
+    />
+    {
+      state.notify &&
+      <Notification className='storybook-data-table__notification' handleRemove={() => setState({notify: null})}>
+        <h2>Details</h2>
+        <div className='storybook-data-table__details'>
+          <Icon name='avatar' /> Assignee: {state.notify.assignee}
+        </div>
+        <div className='storybook-data-table__details'>
+          <Icon name='date_range' /> Opened: {state.notify.opened}
+        </div>
+        <div className='storybook-data-table__details'>
+          <Icon name='date_range' /> Date of ride: {state.notify.date_of_ride}
+        </div>
+        <div className='storybook-data-table__details'>
+          <Icon name='flight_takeoff' /> Pickup / Dropoff: {state.notify.pickup}
+        </div>
+      </Notification>
+    }
+  </div>
+), () => ({ notify: null }))
+
 addStory('sortable', readme, () => (
   <DataTable
     actions={actions}
     columns={columnsCustomHeaders}
     data={tableData}
-    onClick={action('onClick')}
     onSort={action('onSort')}
     sortable
   />
@@ -178,7 +216,7 @@ addStory('expandable rows', readme, () => (
   <DataTable
     actions={actions}
     columns={columnsCustomHeaders}
-    data={tableData}
+    data={tableDataCollapse}
     expandRender={expandRender}
     onClick={action('onClick')}
     onSort={action('onSort')}

--- a/packages/data-table/stories.js
+++ b/packages/data-table/stories.js
@@ -175,6 +175,7 @@ addStory('sortable', readme, () => (
     actions={actions}
     columns={columnsCustomHeaders}
     data={tableData}
+    onClick={action('onClick')}
     onSort={action('onSort')}
     sortable
   />
@@ -186,6 +187,7 @@ addStory('expandable rows', readme, () => (
     columns={columnsCustomHeaders}
     data={tableData}
     expandRender={expandRender}
+    onClick={action('onClick')}
     onSort={action('onSort')}
     sortable
   />

--- a/packages/data-table/stories.js
+++ b/packages/data-table/stories.js
@@ -17,14 +17,30 @@ const addStory = createStoriesFactory('DataTable', module, {
 // Mocks
 // Mock data
 const tableData = [
-  { id: 0, opened: '17th Jan 2018', date_of_ride: '19th Feb 2018', assignee: 'Donald Truck', pickup: 'Krakow' },
-  { id: 1, opened: '16th Jan 2018', date_of_ride: '18th Feb 2018', assignee: 'John Smith', pickup: 'Berlin' },
-  { id: 2, opened: '18th Jan 2018', date_of_ride: '20th Feb 2018', assignee: 'Matthew McMouse', pickup: 'Warszawa' },
-  { id: 3, opened: '19th Jan 2018', date_of_ride: '21th Feb 2018', assignee: 'Andrew Planet', pickup: 'Frankfurt' },
-  { id: 4, opened: '20th Jan 2018', date_of_ride: '22th Feb 2018', assignee: 'Drew Drew', pickup: 'Dortmund' },
-  { id: 5, opened: '21th Jan 2018', date_of_ride: '23th Feb 2018', assignee: 'John Bull', pickup: 'Paris' },
-  { id: 6, opened: '22th Jan 2018', date_of_ride: '24th Feb 2018', assignee: 'Josh Josh', pickup: 'Barcelona' },
-  { id: 7, opened: '23th Jan 2018', date_of_ride: '25th Feb 2018', assignee: 'John Smith', pickup: 'London' }
+  {
+    // id: 0,
+    opened: '17th Jan 2018', date_of_ride: '19th Feb 2018', assignee: 'Donald Truck', pickup: 'Krakow' },
+  {
+    // id: 1,
+    opened: '16th Jan 2018', date_of_ride: '18th Feb 2018', assignee: 'John Smith', pickup: 'Berlin' },
+  {
+    // id: 2,
+    opened: '18th Jan 2018', date_of_ride: '20th Feb 2018', assignee: 'Matthew McMouse', pickup: 'Warszawa' },
+  {
+    // id: 3,
+    opened: '19th Jan 2018', date_of_ride: '21th Feb 2018', assignee: 'Andrew Planet', pickup: 'Frankfurt' },
+  {
+    // id: 4,
+    opened: '20th Jan 2018', date_of_ride: '22th Feb 2018', assignee: 'Drew Drew', pickup: 'Dortmund' },
+  {
+    // id: 5,
+    opened: '21th Jan 2018', date_of_ride: '23th Feb 2018', assignee: 'John Bull', pickup: 'Paris' },
+  {
+    // id: 6,
+    opened: '22th Jan 2018', date_of_ride: '24th Feb 2018', assignee: 'Josh Josh', pickup: 'Barcelona' },
+  {
+    // id: 7,
+    opened: '23th Jan 2018', date_of_ride: '25th Feb 2018', assignee: 'John Smith', pickup: 'London' }
 ]
 const tableDataNoAssignee = [
   { id: 0, opened: '17th Jan 2018', date_of_ride: '19th Feb 2018', assignee: 'Donald Truck', pickup: 'Krakow' },
@@ -84,6 +100,13 @@ const actionsConditional = [
   { label: 'Duplicate', onClick: action('Duplicate'), icon: 'control_point_duplicate', condition: row => row.assignee },
   { label: 'Remove', onClick: action('Remove'), icon: 'clear' }
 ]
+
+// Mock expand render
+function expandRender (item) {
+  return (
+    <div>{item.id} {item.opened} {item.assignee} </div>
+  )
+}
 
 // Stories
 addStory('initial', readme, () => (
@@ -152,6 +175,17 @@ addStory('sortable', readme, () => (
     actions={actions}
     columns={columnsCustomHeaders}
     data={tableData}
+    onSort={action('onSort')}
+    sortable
+  />
+))
+
+addStory('expandable rows', readme, () => (
+  <DataTable
+    actions={actions}
+    columns={columnsCustomHeaders}
+    data={tableData}
+    expandRender={expandRender}
     onSort={action('onSort')}
     sortable
   />

--- a/packages/data-table/stories.js
+++ b/packages/data-table/stories.js
@@ -18,30 +18,23 @@ const addStory = createStoriesFactory('DataTable', module, {
 // Mock data
 const tableData = [
   {
-    // id: 0,
-    opened: '17th Jan 2018', date_of_ride: '19th Feb 2018', assignee: 'Donald Truck', pickup: 'Krakow' },
+    id: 0, opened: '17th Jan 2018', date_of_ride: '19th Feb 2018', assignee: 'Donald Truck', pickup: 'Krakow' },
   {
-    // id: 1,
-    opened: '16th Jan 2018', date_of_ride: '18th Feb 2018', assignee: 'John Smith', pickup: 'Berlin' },
+    id: 1, opened: '16th Jan 2018', date_of_ride: '18th Feb 2018', assignee: 'John Smith', pickup: 'Berlin' },
   {
-    // id: 2,
-    opened: '18th Jan 2018', date_of_ride: '20th Feb 2018', assignee: 'Matthew McMouse', pickup: 'Warszawa' },
+    id: 2, opened: '18th Jan 2018', date_of_ride: '20th Feb 2018', assignee: 'Matthew McMouse', pickup: 'Warszawa' },
   {
-    // id: 3,
-    opened: '19th Jan 2018', date_of_ride: '21th Feb 2018', assignee: 'Andrew Planet', pickup: 'Frankfurt' },
+    id: 3, opened: '19th Jan 2018', date_of_ride: '21th Feb 2018', assignee: 'Andrew Planet', pickup: 'Frankfurt' },
   {
-    // id: 4,
-    opened: '20th Jan 2018', date_of_ride: '22th Feb 2018', assignee: 'Drew Drew', pickup: 'Dortmund' },
+    id: 4, opened: '20th Jan 2018', date_of_ride: '22th Feb 2018', assignee: 'Drew Drew', pickup: 'Dortmund' },
   {
-    // id: 5,
-    opened: '21th Jan 2018', date_of_ride: '23th Feb 2018', assignee: 'John Bull', pickup: 'Paris' },
+    id: 5, opened: '21th Jan 2018', date_of_ride: '23th Feb 2018', assignee: 'John Bull', pickup: 'Paris' },
   {
-    // id: 6,
-    opened: '22th Jan 2018', date_of_ride: '24th Feb 2018', assignee: 'Josh Josh', pickup: 'Barcelona' },
+    id: 6, opened: '22th Jan 2018', date_of_ride: '24th Feb 2018', assignee: 'Josh Josh', pickup: 'Barcelona' },
   {
-    // id: 7,
-    opened: '23th Jan 2018', date_of_ride: '25th Feb 2018', assignee: 'John Smith', pickup: 'London' }
+    id: 7, opened: '23th Jan 2018', date_of_ride: '25th Feb 2018', assignee: 'John Smith', pickup: 'London' }
 ]
+
 const tableDataNoAssignee = [
   { id: 0, opened: '17th Jan 2018', date_of_ride: '19th Feb 2018', assignee: 'Donald Truck', pickup: 'Krakow' },
   { id: 1, opened: '16th Jan 2018', date_of_ride: '18th Feb 2018', assignee: '', pickup: 'Berlin' },

--- a/packages/data-table/styles/config.sass
+++ b/packages/data-table/styles/config.sass
@@ -1,7 +1,23 @@
 @import '~@talixo/shared/styles/config'
 
-$color-active: $color-talixo-gray !default
-$color-inactive: $color-talixo-lighter-gray !default
+$data-table-color-active: $color-talixo-gray !default
+$data-table-color-inactive: $color-talixo-lighter-gray !default
 
-$sort-arrow-transition: all ease-out .2s
-$sort-arrow-margin: dp(-.75) dp(.25)
+$data-table-row-text-color: $color-black !default
+$data-table-row-background-color: #fff !default
+$data-table-row-background-hover-color: #f9f9f9 !default
+
+$data-table-even-row-text-color: $color-black !default
+$data-table-even-row-background-color: $color-tab-inactive !default
+$data-table-even-row-background-hover-color: darken($color-tab-inactive, 2%) !default
+
+$data-table-collapse-text-color: $data-table-row-text-color !default
+$data-table-collapse-background-color: $data-table-row-background-color !default
+$data-table-collapse-background-hover-color: $data-table-row-background-hover-color !default
+
+$data-table-even-collapse-text-color: $data-table-even-row-text-color !default
+$data-table-even-collapse-background-color: $data-table-even-row-background-color !default
+$data-table-even-collapse-background-hover-color: $data-table-even-row-background-hover-color !default
+
+$data-table-transition: ease-out .2s
+$data-table-sort-arrow-margin: dp(-.75) dp(.25)

--- a/packages/data-table/styles/geometry.sass
+++ b/packages/data-table/styles/geometry.sass
@@ -1,7 +1,6 @@
 @import './config'
 
 @include module('data-table')
-
   &__header, &__cell
     &--clickable
       cursor: pointer
@@ -33,33 +32,35 @@
         #{prefix('data-table', 'cell')}, #{prefix('table', 'actions')}
           background: $data-table-even-row-background-hover-color
 
-  &__collapse
+  & &__collapse
     transition: $data-table-transition
 
     #{prefix('data-table', 'collapse', 'cell')}
-      color: $data-table-collapse-text-color !important
-      background: $data-table-collapse-background-color !important
+      color: $data-table-collapse-text-color
+      background: $data-table-collapse-background-color
       transition: padding-top, padding-bottom $data-table-transition
 
       > *
         transition: max-height, opacity $data-table-transition
-        max-height: fit-content
+        max-height: none
+
     &:hover > #{prefix('data-table', 'collapse', 'cell')}
-      background: $data-table-collapse-background-color !important
+      background: $data-table-collapse-background-color
 
     &--even
       td#{prefix('data-table', 'collapse', 'cell')}
-        color: $data-table-even-collapse-text-color !important
-        background: $data-table-even-collapse-background-color !important
+        color: $data-table-even-collapse-text-color
+        background: $data-table-even-collapse-background-color
 
       &:hover > #{prefix('data-table', 'collapse', 'cell')}
-        background: $data-table-even-collapse-background-color !important
+        background: $data-table-even-collapse-background-color
 
     &--collapsed
       #{prefix('data-table', 'collapse', 'cell')}
         padding: 0
+        overflow: hidden
+
         > *
           transition: max-height $data-table-transition
           max-height: 0
           opacity: 0
-

--- a/packages/data-table/styles/geometry.sass
+++ b/packages/data-table/styles/geometry.sass
@@ -2,11 +2,12 @@
 
 @include module('data-table')
 
-  &__header
+  &__header, &__cell
     &--clickable
       cursor: pointer
       user-select: none
-      
+
+  &__header
     &__arrows
       display: inline-flex
       flex-direction: column
@@ -15,9 +16,50 @@
 
     &__arrow
       &-down, &-up
-        margin: $sort-arrow-margin
-        color: $color-inactive
-        transition: $sort-arrow-transition
+        margin: $data-table-sort-arrow-margin
+        color: $data-table-color-inactive
+        transition: all $data-table-transition
 
         &--selected
-          color: $color-active
+          color: $data-table-color-active
+
+  &__row
+    &--even
+      #{prefix('data-table', 'cell')}, > #{prefix('table', 'actions')}
+        color: $data-table-even-row-text-color
+        background: $data-table-even-row-background-color
+
+      &:hover
+        #{prefix('data-table', 'cell')}, #{prefix('table', 'actions')}
+          background: $data-table-even-row-background-hover-color
+
+  &__collapse
+    transition: $data-table-transition
+
+    #{prefix('data-table', 'collapse', 'cell')}
+      color: $data-table-collapse-text-color !important
+      background: $data-table-collapse-background-color !important
+      transition: padding-top, padding-bottom $data-table-transition
+
+      > *
+        transition: max-height, opacity $data-table-transition
+        max-height: fit-content
+    &:hover > #{prefix('data-table', 'collapse', 'cell')}
+      background: $data-table-collapse-background-color !important
+
+    &--even
+      td#{prefix('data-table', 'collapse', 'cell')}
+        color: $data-table-even-collapse-text-color !important
+        background: $data-table-even-collapse-background-color !important
+
+      &:hover > #{prefix('data-table', 'collapse', 'cell')}
+        background: $data-table-even-collapse-background-color !important
+
+    &--collapsed
+      #{prefix('data-table', 'collapse', 'cell')}
+        padding: 0
+        > *
+          transition: max-height $data-table-transition
+          max-height: 0
+          opacity: 0
+

--- a/packages/data-table/styles/storybook.sass
+++ b/packages/data-table/styles/storybook.sass
@@ -1,0 +1,31 @@
+@import './config'
+
+.storybook-data-table
+  display: flex
+  justify-content: space-around
+
+  &__item
+    padding: dp(3)
+
+    > .talixo-icon
+      color: $color-talixo-gray
+      padding: 0 dp(2)
+      font-size: dp(4)
+
+  &__notification
+    position: fixed !important
+    width: 50% !important
+    top: 25%
+    left: 25%
+
+    .talixo-notification__close
+      font-size: dp(6)
+      padding-top: dp(1.5)
+
+  &__details
+    padding: dp(3) 0
+
+    > .talixo-icon
+      color: $color-talixo-gray
+      padding: 0 dp(3)
+      font-size: dp(4)

--- a/packages/data-table/tests/DataTable.test.js
+++ b/packages/data-table/tests/DataTable.test.js
@@ -1,9 +1,9 @@
 import React from 'react'
 import { shallow } from 'enzyme'
 
-import DataTable from '../src/DataTable'
+import DataTable, { registerElements, generateId } from '../src/DataTable'
 import { moduleName } from '../src/config'
-import { actions, columns, tableData, tableDataSort } from './fixtures/testData'
+import {actions, columns, tableData, tableData2, tableDataNoId, tableDataSort} from './fixtures/testData'
 import { buildClassName } from '@talixo/shared'
 
 const headerCls = buildClassName([ moduleName, 'header' ])
@@ -28,6 +28,64 @@ describe('<DataTable />', () => {
 
     it('renders children correctly', () => {
       expect(wrapper).toMatchSnapshot()
+    })
+
+    it('should apply empty string on sortColumn if not passed from props', () => {
+      expect(wrapper.state().sortColumn).toBe('')
+    })
+
+    it('should apply false on reversedOrder if not passed from props', () => {
+      expect(wrapper.state().reversedOrder).toBe(false)
+    })
+  })
+
+  describe('generating id map', () => {
+    describe('when collection with id is passed', () => {
+      const correctMap = registerElements(tableData, generateId)
+      const props = createProps({ data: tableData })
+      const wrapper = createWrapper(props)
+
+      it('should create map properly', () => {
+        expect(wrapper.state().idStorage).toEqual(correctMap)
+      })
+    })
+
+    describe('when collection without id is passed', () => {
+      const correctMap = registerElements(tableDataNoId, generateId)
+      const props = createProps({ data: tableDataNoId })
+      const wrapper = createWrapper(props)
+
+      it('should create map properly', () => {
+        expect(wrapper.state().idStorage).toEqual(correctMap)
+      })
+    })
+  })
+
+  describe('handling props changes', () => {
+    const props = createProps({
+      sortColumn: columns[1].id,
+      reversedOrder: false
+    })
+    let wrapper
+
+    beforeEach(() => {
+      wrapper = createWrapper(props)
+    })
+
+    it('should change state.sortedData when props.data changes', () => {
+      wrapper.setProps({ data: tableData2 })
+      expect(wrapper.state().sortedData).toBe(tableData2)
+    })
+
+    it('should change sort column when props.sortColumn changes', () => {
+      const newId = columns[2].id
+      wrapper.setProps({ sortColumn: newId })
+      expect(wrapper.state().sortColumn).toBe(newId)
+    })
+
+    it('should change reversedOrder when props.reversedOrder changes', () => {
+      wrapper.setProps({ reversedOrder: true })
+      expect(wrapper.state().reversedOrder).toBe(true)
     })
   })
 

--- a/packages/data-table/tests/TableRow.test.js
+++ b/packages/data-table/tests/TableRow.test.js
@@ -1,12 +1,28 @@
 import React from 'react'
 import { shallow } from 'enzyme'
+import { buildClassName } from '@talixo/shared'
 
 import TableRow from '../src/TableRow'
-import { tableData, actions, columns } from './fixtures/testData'
+import { moduleName } from '../src/config'
+import { generateId, registerElements } from '../src/DataTable'
+
+import { tableData, tableData2, actions, columns } from './fixtures/testData'
+
+// Mock expand render
+function expandRender (item) {
+  return (
+    <div>{item.id} {item.opened} {item.assignee} </div>
+  )
+}
+
+// Helper classes
+const collapseCls = buildClassName([moduleName, 'collapse'])
+const rowCls = buildClassName([moduleName, 'row'])
 
 const createProps = props => ({
   rowData: tableData,
   columns: columns,
+  idStorage: registerElements(tableData, generateId),
   ...props
 })
 const defaultProps = createProps()
@@ -61,5 +77,100 @@ describe('<TableRow />', () => {
       actionButtons.first().simulate('click', {})
       expect(props.actions[0].onClick).toHaveBeenCalledWith(props.rowData[0], expect.anything())
     })
+  })
+
+  describe('collapsing behaviour', () => {
+    const props = createProps({ expandRender })
+    const dataLength = tableData.length
+    const clickedElement = dataLength - 1
+    let wrapper, row
+
+    beforeEach(() => {
+      wrapper = createWrapper(props)
+      row = wrapper.find(`.${rowCls}`).at(clickedElement).children().at(0)
+    })
+
+    it('should render collapsible items', () => {
+      expect(wrapper.find(`.${collapseCls}`).length).toBe(dataLength)
+    })
+
+    it('should render all columns as collapsed', () => {
+      expect(wrapper.find(`.${collapseCls}--collapsed`).length).toBe(dataLength)
+    })
+
+    it('should apply --even modificator to even columns', () => {
+      wrapper.find(`.${collapseCls}`).forEach((node, index) => {
+        const isEven = node.hasClass(`${collapseCls}--even`)
+        if (index % 2 !== 0) {
+          expect(isEven).toBe(true)
+        } else {
+          expect(isEven).toBe(false)
+        }
+      })
+    })
+
+    it('should expand element after clicking on it', () => {
+      row.simulate('click', {})
+      expect(wrapper.find(`.${collapseCls}--collapsed`).length).toBe(dataLength - 1)
+    })
+
+    it('should add element to state.expanded after clicking on it', () => {
+      row.simulate('click', {})
+      expect(wrapper.state().expanded).toContain(clickedElement)
+    })
+
+    it('should collapse element after clicking on it second time', () => {
+      row.simulate('click', {})
+      expect(wrapper.find(`.${collapseCls}--collapsed`).length).toBe(dataLength - 1)
+      row.simulate('click', {})
+      expect(wrapper.find(`.${collapseCls}--collapsed`).length).toBe(dataLength)
+    })
+
+    it('should remove element from state.expanded after clicking on it second time', () => {
+      row.simulate('click', {})
+      expect(wrapper.state().expanded).toContain(clickedElement)
+      row.simulate('click', {})
+      expect(wrapper.state().expanded).toEqual([])
+    })
+  })
+
+  describe('props handling', () => {
+    const props = createProps({
+      expandedRows: [1, 2],
+      onClick: jest.fn()
+    })
+    let wrapper
+
+    beforeEach(() => {
+      wrapper = createWrapper(props)
+    })
+
+    it('should set state.expanded to props.expandedRows', () => {
+      expect(wrapper.state().expanded).toBe(props.expandedRows)
+    })
+
+    it('should change state.expanded when props.expandedRows is updated', () => {
+      const updatedExpanded = [0, 1]
+      wrapper.setProps({ expandedRows: updatedExpanded })
+      expect(wrapper.state().expanded).toBe(updatedExpanded)
+    })
+
+    it('should change state.expanded to empty array when props.rowData is updated', () => {
+      const storageUpdate = registerElements(tableData2, generateId)
+      wrapper.setProps({ rowData: tableData2, idStorage: storageUpdate, expandedRows: null })
+      expect(wrapper.state().expanded).toEqual([])
+    })
+
+    it('should handle onCLick function when row is clicked', () => {
+      const rowIndex = 0
+      const row = wrapper.find(`.${rowCls}`).at(rowIndex).children().at(0)
+      row.simulate('click', {})
+      expect(props.onClick).toHaveBeenCalledTimes(1)
+      expect(props.onClick).toHaveBeenCalledWith(tableData2[rowIndex], expect.anything())
+    })
+  })
+
+  describe('event handling', () => {
+
   })
 })

--- a/packages/data-table/tests/__snapshots__/DataTable.test.js.snap
+++ b/packages/data-table/tests/__snapshots__/DataTable.test.js.snap
@@ -97,6 +97,31 @@ exports[`<DataTable /> rendering renders children correctly 1`] = `
           },
         ]
       }
+      idStorage={
+        Map {
+          Object {
+            "assignee": "John Smith",
+            "date_of_ride": "18th Feb 2018",
+            "id": 0,
+            "opened": "16th Jan 2018",
+            "pickup": "Berlin SXF Alexanderplatz",
+          } => 0,
+          Object {
+            "assignee": "",
+            "date_of_ride": "19th Feb 2018",
+            "id": 1,
+            "opened": "17th Jan 2018",
+            "pickup": "Krakow",
+          } => 1,
+          Object {
+            "assignee": "Mickey Mouse",
+            "date_of_ride": "20th Feb 2018",
+            "id": 2,
+            "opened": "18th Jan 2018",
+            "pickup": "Warszawa",
+          } => 2,
+        }
+      }
       rowData={
         Array [
           Object {

--- a/packages/data-table/tests/__snapshots__/TableRow.test.js.snap
+++ b/packages/data-table/tests/__snapshots__/TableRow.test.js.snap
@@ -2,102 +2,144 @@
 
 exports[`<TableRow /> rendering renders children correctly 1`] = `
 <React.Fragment>
-  <Row
+  <React.Fragment
     key="0"
   >
-    <Cell
-      key="id"
+    <Row
+      className="talixo-data-table__row"
     >
-      0
-    </Cell>
-    <Cell
-      key="opened"
-    >
-      16th Jan 2018
-    </Cell>
-    <Cell
-      key="assignee"
-    >
-      <span
-        className="test-span"
+      <Cell
+        className="talixo-data-table__cell"
+        key="id"
+        onClick={[Function]}
       >
-        John Smith
-      </span>
-    </Cell>
-    <Cell
-      key="date_of_ride"
-    >
-      18th Feb 2018
-    </Cell>
-    <Cell
-      key="pickup"
-    >
-      Berlin SXF Alexanderplatz
-    </Cell>
-  </Row>
-  <Row
+        0
+      </Cell>
+      <Cell
+        className="talixo-data-table__cell"
+        key="opened"
+        onClick={[Function]}
+      >
+        16th Jan 2018
+      </Cell>
+      <Cell
+        className="talixo-data-table__cell"
+        key="assignee"
+        onClick={[Function]}
+      >
+        <span
+          className="test-span"
+        >
+          John Smith
+        </span>
+      </Cell>
+      <Cell
+        className="talixo-data-table__cell"
+        key="date_of_ride"
+        onClick={[Function]}
+      >
+        18th Feb 2018
+      </Cell>
+      <Cell
+        className="talixo-data-table__cell"
+        key="pickup"
+        onClick={[Function]}
+      >
+        Berlin SXF Alexanderplatz
+      </Cell>
+    </Row>
+  </React.Fragment>
+  <React.Fragment
     key="1"
   >
-    <Cell
-      key="id"
+    <Row
+      className="talixo-data-table__row talixo-data-table__row--even"
     >
-      1
-    </Cell>
-    <Cell
-      key="opened"
-    >
-      17th Jan 2018
-    </Cell>
-    <Cell
-      key="assignee"
-    >
-      <span
-        className="test-span"
-      />
-    </Cell>
-    <Cell
-      key="date_of_ride"
-    >
-      19th Feb 2018
-    </Cell>
-    <Cell
-      key="pickup"
-    >
-      Krakow
-    </Cell>
-  </Row>
-  <Row
+      <Cell
+        className="talixo-data-table__cell"
+        key="id"
+        onClick={[Function]}
+      >
+        1
+      </Cell>
+      <Cell
+        className="talixo-data-table__cell"
+        key="opened"
+        onClick={[Function]}
+      >
+        17th Jan 2018
+      </Cell>
+      <Cell
+        className="talixo-data-table__cell"
+        key="assignee"
+        onClick={[Function]}
+      >
+        <span
+          className="test-span"
+        />
+      </Cell>
+      <Cell
+        className="talixo-data-table__cell"
+        key="date_of_ride"
+        onClick={[Function]}
+      >
+        19th Feb 2018
+      </Cell>
+      <Cell
+        className="talixo-data-table__cell"
+        key="pickup"
+        onClick={[Function]}
+      >
+        Krakow
+      </Cell>
+    </Row>
+  </React.Fragment>
+  <React.Fragment
     key="2"
   >
-    <Cell
-      key="id"
+    <Row
+      className="talixo-data-table__row"
     >
-      2
-    </Cell>
-    <Cell
-      key="opened"
-    >
-      18th Jan 2018
-    </Cell>
-    <Cell
-      key="assignee"
-    >
-      <span
-        className="test-span"
+      <Cell
+        className="talixo-data-table__cell"
+        key="id"
+        onClick={[Function]}
       >
-        Mickey Mouse
-      </span>
-    </Cell>
-    <Cell
-      key="date_of_ride"
-    >
-      20th Feb 2018
-    </Cell>
-    <Cell
-      key="pickup"
-    >
-      Warszawa
-    </Cell>
-  </Row>
+        2
+      </Cell>
+      <Cell
+        className="talixo-data-table__cell"
+        key="opened"
+        onClick={[Function]}
+      >
+        18th Jan 2018
+      </Cell>
+      <Cell
+        className="talixo-data-table__cell"
+        key="assignee"
+        onClick={[Function]}
+      >
+        <span
+          className="test-span"
+        >
+          Mickey Mouse
+        </span>
+      </Cell>
+      <Cell
+        className="talixo-data-table__cell"
+        key="date_of_ride"
+        onClick={[Function]}
+      >
+        20th Feb 2018
+      </Cell>
+      <Cell
+        className="talixo-data-table__cell"
+        key="pickup"
+        onClick={[Function]}
+      >
+        Warszawa
+      </Cell>
+    </Row>
+  </React.Fragment>
 </React.Fragment>
 `;

--- a/packages/data-table/tests/fixtures/testData.js
+++ b/packages/data-table/tests/fixtures/testData.js
@@ -7,6 +7,18 @@ export const tableData = [
   { id: 2, opened: '18th Jan 2018', date_of_ride: '20th Feb 2018', assignee: 'Mickey Mouse', pickup: 'Warszawa' }
 ]
 
+export const tableData2 = [
+  { id: 0, opened: '16th Jan 2018', date_of_ride: '18th Feb 2018', assignee: 'John Smith', pickup: 'Berlin SXF Alexanderplatz' },
+  { id: 1, opened: '17th Jan 2018', date_of_ride: '19th Feb 2018', assignee: '', pickup: 'Krakow' },
+  { id: 2, opened: '18th Jan 2018', date_of_ride: '20th Feb 2018', assignee: 'Mickey Mouse', pickup: 'Warszawa' }
+]
+
+export const tableDataNoId = [
+  { opened: '16th Jan 2018', date_of_ride: '18th Feb 2018', assignee: 'John Smith', pickup: 'Berlin SXF Alexanderplatz' },
+  { opened: '17th Jan 2018', date_of_ride: '19th Feb 2018', assignee: '', pickup: 'Krakow' },
+  { opened: '18th Jan 2018', date_of_ride: '20th Feb 2018', assignee: 'Mickey Mouse', pickup: 'Warszawa' }
+]
+
 export const tableDataSort = (col, dir = 'asc') => orderBy(tableData, col, dir)
 
 export const columns = [


### PR DESCRIPTION
#### Task

- **Issue or task referred:** UI-62
- **Feature or Bugfix:** Feature

I have added a possibility to expand rows using custom renderer.
Additionally I have fixed passing onSort props to header, addded a row onClick handler and idBuild function.

#### Checklist

- [x] Required unit tests prepared
- [x] Documentation prepared
- [x] External licenses validated (ideally MIT)
