### PR TITLE
Block `react-text-mask` version to `5.4.1`

### DIFF
--- a/packages/credit-card/README.md
+++ b/packages/credit-card/README.md
@@ -20,7 +20,7 @@ Your package should additionally have some extra dependencies:
 - `prop-types: ^15.6.1`
 - `react: ^16.2.0`
 - `react-dom: ^16.2.0`
-- `react-text-mask: ^5.4.1`
+- `react-text-mask: 5.4.1`
 
 These packages are required by `@talixo/credit-card`, but you have to install them manually,
 to avoid having different versions of these in your application.

--- a/packages/credit-card/package.json
+++ b/packages/credit-card/package.json
@@ -32,7 +32,7 @@
     "prop-types": "^15.6.1",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
-    "react-text-mask": "^5.4.1"
+    "react-text-mask": "5.4.1"
   },
   "peerDependencies": {
     "@talixo/combo-box": "^0.1.0",
@@ -44,6 +44,6 @@
     "prop-types": "^15.6.1",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
-    "react-text-mask": "^5.4.1"
+    "react-text-mask": "5.4.1"
   }
 }

--- a/packages/phone-input/README.md
+++ b/packages/phone-input/README.md
@@ -18,7 +18,7 @@ Your package should additionally have some extra dependencies:
 - `prop-types: ^15.6.1`
 - `react: ^16.2.0`
 - `react-dom: ^16.2.0`
-- `react-text-mask: ^5.4.1`
+- `react-text-mask: 5.4.1`
 
 These packages are required by `@talixo/phone-input`, but you have to install them manually,
 to avoid having different versions of these in your application.

--- a/packages/phone-input/package.json
+++ b/packages/phone-input/package.json
@@ -30,7 +30,7 @@
     "prop-types": "^15.6.1",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
-    "react-text-mask": "^5.4.1"
+    "react-text-mask": "5.4.1"
   },
   "peerDependencies": {
     "@talixo/combo-box": "^0.1.0",
@@ -40,6 +40,6 @@
     "prop-types": "^15.6.1",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
-    "react-text-mask": "^5.4.1"
+    "react-text-mask": "5.4.1"
   }
 }

--- a/packages/text-input/package.json
+++ b/packages/text-input/package.json
@@ -29,7 +29,7 @@
     "prop-types": "^15.6.1",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
-    "react-text-mask": "^5.4.1"
+    "react-text-mask": "5.4.1"
   },
   "peerDependencies": {
     "@talixo/shared": "^0.1.0",


### PR DESCRIPTION
#### Task

`react-text-mask` has problems with new version, so we need to suspend it.

#### Checklist

- [x] Required unit tests prepared
- [x] Documentation prepared
- [x] External licenses validated (ideally MIT)
