### PR TITLE
[UI-79] Checkbox Label should be always on right of Checkbox tick

### DIFF
--- a/packages/checkbox/stories.js
+++ b/packages/checkbox/stories.js
@@ -39,3 +39,11 @@ addStory('long checkbox label', readme, () => (
     </div>
   </div>
 ))
+
+addStory('RTL: long checkbox label', readme, () => (
+  <div dir='rtl'>
+    <div style={{ background: '#f5f5f5', padding: 20, width: 300 }}>
+      <Checkbox>Lorem ipsum dolor sit amet enim. Etiam ullamcorper. Suspendisse a pellentesque dui, non felis. Maecenas malesuada elit lectus felis, malesuada ultricies.</Checkbox>
+    </div>
+  </div>
+))

--- a/packages/checkbox/stories.js
+++ b/packages/checkbox/stories.js
@@ -31,3 +31,11 @@ addStory('default', readme, () => (
     </Checkbox>
   </div>
 ))
+
+addStory('long checkbox label', readme, () => (
+  <div>
+    <div style={{ background: '#f5f5f5', padding: 20, width: 300 }}>
+      <Checkbox>Lorem ipsum dolor sit amet enim. Etiam ullamcorper. Suspendisse a pellentesque dui, non felis. Maecenas malesuada elit lectus felis, malesuada ultricies.</Checkbox>
+    </div>
+  </div>
+))

--- a/packages/checkbox/styles/main.sass
+++ b/packages/checkbox/styles/main.sass
@@ -11,6 +11,7 @@ $checkbox-box-shadow-size: ($checkbox-box-size - $checkbox-box-tick-size) / 2
     display: none
 
   > input + span
+    display: block
     padding-left: $checkbox-box-margin + $checkbox-box-size
     padding-right: $checkbox-box-margin
     color: $checkbox-text-color

--- a/packages/checkbox/styles/main.sass
+++ b/packages/checkbox/styles/main.sass
@@ -11,7 +11,7 @@ $checkbox-box-shadow-size: ($checkbox-box-size - $checkbox-box-tick-size) / 2
     display: none
 
   > input + span
-    display: block
+    display: inline-flex
     padding-left: $checkbox-box-margin + $checkbox-box-size
     padding-right: $checkbox-box-margin
     color: $checkbox-text-color

--- a/packages/checkbox/styles/main.sass
+++ b/packages/checkbox/styles/main.sass
@@ -69,6 +69,10 @@ $checkbox-box-shadow-size: ($checkbox-box-size - $checkbox-box-tick-size) / 2
   &--error > input:checked:not(:disabled) + span:before
     background-color: $checkbox-error-box-background-color
 
-  [dir=rtl] > input + span
+  [dir=rtl] & > input + span
     padding-left: $checkbox-box-margin
     padding-right: $checkbox-box-margin + $checkbox-box-size
+
+  [dir=rtl] & > input + span:before
+      left: auto
+      right: 0


### PR DESCRIPTION
#### Task

- **Issue or task referred:** UI-79
- **Feature or Bugfix:** Bugfix

Checkbox Label should be always on the right of Checkbox tick

#### Checklist

- [x] Required unit tests prepared
- [x] Documentation prepared
- [x] External licenses validated (ideally MIT)
