### PR TITLE
[UI-93] Do not pass `defaultChecked` down to input[type="checkbox"]

### DIFF
--- a/packages/checkbox/src/Checkbox.js
+++ b/packages/checkbox/src/Checkbox.js
@@ -67,7 +67,7 @@ class Checkbox extends React.PureComponent {
   }
 
   render () {
-    const { children, className, error, style, value, onChange, ...passedProps } = this.props
+    const { children, className, error, style, value, onChange, defaultChecked, ...passedProps } = this.props
     const _value = this.state.value
 
     const clsName = buildClassName(moduleName, className, { error })

--- a/packages/checkbox/tests/__snapshots__/Checkbox.test.js.snap
+++ b/packages/checkbox/tests/__snapshots__/Checkbox.test.js.snap
@@ -6,7 +6,6 @@ exports[`<Checkbox /> renders children correctly 1`] = `
 >
   <input
     checked={false}
-    defaultChecked={false}
     onChange={[Function]}
     type="checkbox"
   />


### PR DESCRIPTION
#### Task

- **Issue or task referred:** UI-93
- **Feature or Bugfix:** Feature

Do not pass `defaultChecked` down to input[type="checkbox"].

#### Checklist

- [x] Required unit tests prepared
- [x] Documentation prepared
- [x] External licenses validated (ideally MIT)
