### PR TITLE
[UI-91] Fix margins in OptionsInput tooltip

### DIFF
--- a/packages/options-input/styles/config.sass
+++ b/packages/options-input/styles/config.sass
@@ -49,4 +49,4 @@ $options-input-label-line-height: 1.1em !default
 
 $options-input-tooltip-title-font-weight: $options-input-label-title-font-weight !default
 $options-input-tooltip-description-font-weight: $options-input-label-description-font-weight !default
-$options-input-tooltip-title-margin: dp(1) !default
+$options-input-tooltip-title-margin: dp(0.5) !default

--- a/packages/options-input/styles/main.sass
+++ b/packages/options-input/styles/main.sass
@@ -114,11 +114,11 @@
   &-tooltip__title
     display: block
     font-weight: $options-input-tooltip-title-font-weight
-    margin-bottom: $options-input-tooltip-title-margin
 
   &-tooltip__description
     display: block
     font-weight: $options-input-tooltip-description-font-weight
+    margin-top: $options-input-tooltip-title-margin
 
   @include module('text-input')
     input, input:hover, input:focus


### PR DESCRIPTION
#### Task

- **Issue or task referred:** UI-91
- **Feature or Bugfix:** Bugfix

Fix margins in OptionsInput tooltip, especially when there is no additional description.

#### Checklist

- [x] Required unit tests prepared
- [x] Documentation prepared
- [x] External licenses validated (ideally MIT)
