### PR TITLE
Feature/ui 106 add possibility to close options input by arrow

### DIFF
--- a/packages/options-input/src/OptionsInput.js
+++ b/packages/options-input/src/OptionsInput.js
@@ -252,6 +252,11 @@ class OptionsInput extends React.PureComponent {
     }
   }
 
+  handleClickIcon (e) {
+    e.stopPropagation()
+    this.toggle()
+  }
+
   render () {
     const {
       options, className, persistentOptions, onClick, onChange, onFocus, onBlur,
@@ -279,7 +284,10 @@ class OptionsInput extends React.PureComponent {
             value={value}
           />
 
-          <Icon name={open ? 'keyboard_arrow_up' : 'keyboard_arrow_down'} />
+          <Icon
+            name={open ? 'keyboard_arrow_up' : 'keyboard_arrow_down'}
+            onClick={(e) => this.handleClickIcon(e)}
+          />
         </button>
         <OptionsInputList
           options={options}

--- a/packages/options-input/styles/main.sass
+++ b/packages/options-input/styles/main.sass
@@ -27,10 +27,16 @@
       background-color: $options-input-hover-background-color
       border-color: $options-input-hover-border-color
       color: $options-input-hover-text-color
+    
+    &:focus
+      > #{prefix('icon')}
+        pointer-events: auto
+
 
     > #{prefix('icon')}
       margin-left: $options-input-arrow-margin
       font-size: $options-input-arrow-size
+      pointer-events: none
 
   &-option
     display: inline-flex

--- a/packages/options-input/tests/OptionsInput.test.js
+++ b/packages/options-input/tests/OptionsInput.test.js
@@ -128,4 +128,16 @@ describe('<OptionsInput />', () => {
 
     wrapper.unmount()
   })
+
+  it('close options input when click on arrow', () => {
+    const wrapper = mount(<OptionsInput options={options} />)
+
+    expect(wrapper.state('open')).toBe(false)
+
+    wrapper.find('.talixo-icon').at(2).simulate('click')
+
+    expect(wrapper.state('open')).toBe(true)
+
+    wrapper.unmount()
+  })
 })

--- a/packages/options-input/tests/__snapshots__/OptionsInput.test.js.snap
+++ b/packages/options-input/tests/__snapshots__/OptionsInput.test.js.snap
@@ -40,6 +40,7 @@ exports[`<OptionsInput /> renders children correctly 1`] = `
     />
     <Icon
       name="keyboard_arrow_down"
+      onClick={[Function]}
     />
   </button>
   <OptionsInputList


### PR DESCRIPTION
#### Task

- **Issue or task referred:** UI-106
- **Feature or Bugfix:** Bugfix

Now user can close options input by clicking on arrow.

#### Checklist

- [ ] Required unit tests prepared
- [ ] Documentation prepared
- [ ] External licenses validated (ideally MIT)
