### PR TITLE
[UI-111] MaskedInput passes name prop to the wrapper

### DIFF
--- a/packages/masked-input/src/MaskedInput.js
+++ b/packages/masked-input/src/MaskedInput.js
@@ -167,7 +167,7 @@ class MaskedInput extends React.Component {
 
   render () {
     const {
-      className, error, onBlur, onFocus, onChange, children,
+      className, error, onBlur, onFocus, onChange, children, name,
       renderMask, id, placeholder, value: _value, ...passedProps
     } = this.props
     const { focused, value } = this.state


### PR DESCRIPTION
#### Task

- **Issue or task referred:** UI-111
- **Feature or Bugfix:** Bugfix
